### PR TITLE
Fix delay rounding issue

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -251,8 +251,8 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
                     // Support frame delays as low as `kDelayTimeIntervalMinimum`, with anything below being rounded up to `kDelayTimeIntervalDefault` for legacy compatibility.
                     // This is how the fastest browsers do it as per 2012: http://nullsleep.tumblr.com/post/16524517190/animated-gif-minimum-frame-delay-browser-compatibility
                     const NSTimeInterval kDelayTimeIntervalMinimum = 0.02;
-
-                    if (([delayTime floatValue] - (float)kDelayTimeIntervalMinimum) < -FLT_EPSILON) {
+                    // To support the minimum even when rounding errors occur, use an epsilon when comparing. We downcast to float because that's what we get for delayTime from ImageIO.
+                    if ([delayTime floatValue] < ((float)kDelayTimeIntervalMinimum - FLT_EPSILON)) {
                         NSLog(@"Verbose: Rounding frame %zu's `delayTime` from %f up to default %f (minimum supported: %f).", i, [delayTime floatValue], kDelayTimeIntervalDefault, kDelayTimeIntervalMinimum);
                         delayTime = @(kDelayTimeIntervalDefault);
                     }


### PR DESCRIPTION
Fixes issue #20. I am playing safe here and use FLT_EPSILON in case of fuzzy floats, even though I can't see how it can happen here because tools like convert round delay so the minimal step possible is 0.01.
