### PR TITLE
Fix undeclared 'BYTE_SIZE' in Xcode 6

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -13,7 +13,13 @@
 #import <CoreGraphics/CoreGraphics.h>
 
 
+// From vm_param.h, define for iOS 8.0 or higher to build on device.
+#ifndef BYTE_SIZE
+#define BYTE_SIZE 8 // byte size in bits
+#endif
+
 #define MEGABYTE (1024 * 1024)
+
 
 // An animated image's data size (dimensions * frameCount) category; its value is the max allowed memory (in MB).
 // E.g.: A 100x200px GIF with 30 frames is ~2.3MB in our pixel format and would fall into the `FLAnimatedImageDataSizeCategoryAll` category.


### PR DESCRIPTION
When compiling for device with Xcode 6 (as of per beta 4), 'BYTE_SIZE' can't be found anymore (vm_param.h) and building for device fails.

This fix declares this macro if it isn't already.
