### PR TITLE
Calling [super setImage] apparently doesn't set the layer contents…

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -127,6 +127,7 @@
         self.animatedImage = nil;
     }
     
+    self.layer.contents = (id)[image CGImage];
     super.image = image;
 }
 


### PR DESCRIPTION
This fixes an issue where setting the image one time works, but
setting it the next time seems to clear out the image.
