### PR TITLE
Fix Sample Project Debug Views

### DIFF
--- a/FLAnimatedImageDemo/RootViewController.m
+++ b/FLAnimatedImageDemo/RootViewController.m
@@ -78,6 +78,13 @@
         
         dispatch_async(dispatch_get_main_queue(), ^{
             self.imageView2.animatedImage = animatedImage2;
+            
+            // Set up debug UI for image 2
+            self.imageView2.debug_delegate = self.debugView2;
+            animatedImage2.debug_delegate = self.debugView2;
+            self.debugView2.imageView = self.imageView2;
+            self.debugView2.image = animatedImage2;
+            self.imageView2.userInteractionEnabled = YES;
         });
     });
     
@@ -98,6 +105,13 @@
         
         dispatch_async(dispatch_get_main_queue(), ^{
             self.imageView3.animatedImage = animatedImage3;
+            
+            // Set up debug UI for image 3
+            self.imageView3.debug_delegate = self.debugView3;
+            animatedImage3.debug_delegate = self.debugView3;
+            self.debugView3.imageView = self.imageView3;
+            self.debugView3.image = animatedImage3;
+            self.imageView3.userInteractionEnabled = YES;
         });
     });
     
@@ -111,18 +125,6 @@
     self.debugView1.imageView = self.imageView1;
     self.debugView1.image = animatedImage1;
     self.imageView1.userInteractionEnabled = YES;
-    
-    self.imageView2.debug_delegate = self.debugView2;
-    animatedImage2.debug_delegate = self.debugView2;
-    self.debugView2.imageView = self.imageView2;
-    self.debugView2.image = animatedImage2;
-    self.imageView2.userInteractionEnabled = YES;
-
-    self.imageView3.debug_delegate = self.debugView3;
-    animatedImage3.debug_delegate = self.debugView3;
-    self.debugView3.imageView = self.imageView3;
-    self.debugView3.image = animatedImage3;
-    self.imageView3.userInteractionEnabled = YES;
 }
 
 


### PR DESCRIPTION
In 1.0.1 async loading was added to the images in the sample project, however the debug views associated with the images loaded asynchronously weren't updated. This made two of the image views have no debugging view.

Before:

![ios simulator screen shot aug 14 2014 9 45 31 am](https://cloud.githubusercontent.com/assets/522951/3923345/a09b2284-23d2-11e4-9e83-17f665d0c5f4.png)

After:

![ios simulator screen shot aug 14 2014 9 45 17 am](https://cloud.githubusercontent.com/assets/522951/3923348/a453fe14-23d2-11e4-89ce-18d99382508f.png)
