### PR TITLE
updated animatedImage setter for fixing image disappear issue

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -35,34 +35,38 @@
 
 - (void)setAnimatedImage:(FLAnimatedImage *)animatedImage
 {
-    if (![_animatedImage isEqual:animatedImage]) {
-        if (animatedImage) {
-            // Clear out the image.
-            super.image = nil;
-        } else {
-            // Stop animating before the animated image gets cleared out.
-            [self stopAnimating];
-        }
-        
-        _animatedImage = animatedImage;
-        
-        self.currentFrame = animatedImage.posterImage;
-        self.currentFrameIndex = 0;
-        if (animatedImage.loopCount > 0) {
-            self.loopCountdown = animatedImage.loopCount;
-        } else {
-            self.loopCountdown = NSUIntegerMax;
-        }
-        self.accumulator = 0.0;
-        
-        // Start animating after the new animated image has been set.
-        [self updateShouldAnimate];
-        if (self.shouldAnimate) {
-            [self startAnimating];
-        }
-        
-        [self.layer setNeedsDisplay];
+    // If animated images are the same then return right away.
+    // `==` for nil case
+    if (_animatedImage == animatedImage || [_animatedImage isEqual:animatedImage]) {
+        return;
     }
+    
+    if (animatedImage) {
+        // Clear out the image.
+        super.image = nil;
+    } else {
+        // Stop animating before the animated image gets cleared out.
+        [self stopAnimating];
+    }
+    
+    _animatedImage = animatedImage;
+    
+    self.currentFrame = animatedImage.posterImage;
+    self.currentFrameIndex = 0;
+    if (animatedImage.loopCount > 0) {
+        self.loopCountdown = animatedImage.loopCount;
+    } else {
+        self.loopCountdown = NSUIntegerMax;
+    }
+    self.accumulator = 0.0;
+    
+    // Start animating after the new animated image has been set.
+    [self updateShouldAnimate];
+    if (self.shouldAnimate) {
+        [self startAnimating];
+    }
+    
+    [self.layer setNeedsDisplay];
 }
 
 


### PR DESCRIPTION
If we set still UIImage more than once the image will disappear.
The `setImage` method will call setAnimatedImage which casing this problem.
The reason is that calling `setNeedDisplay` the existing content in the layer will be removed it and original code doesn't handle nil case so it pass checking.

```
- (void)setNeedsDisplay
Description 
Marks the layer’s contents as needing to be updated.
Calling this method causes the layer to recache its content. This results in the layer potentially calling either the displayLayer: or drawLayer:inContext: method of its delegate. The existing content in the layer’s contents property is removed to make way for the new content.
```
