### PR TITLE
Disable highlighting for animated image view

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -39,6 +39,7 @@
         if (animatedImage) {
             // Clear out the image.
             super.image = nil;
+            super.highlighted = NO;
         } else {
             // Stop animating before the animated image gets cleared out.
             [self stopAnimating];
@@ -176,6 +177,17 @@
         isAnimating = [super isAnimating];
     }
     return isAnimating;
+}
+
+
+#pragma mark Highlighted Image Unsupport
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+    // Highlighted image is unsupported for animated images, but implementing it breaks the image view when embedded in a UICollectionViewCell.
+    if (!self.animatedImage) {
+        [super setHighlighted:highlighted];
+    }
 }
 
 


### PR DESCRIPTION
It's broken when `highlighted` is set, so don't let it get set when animated. Since `UICollectionViewCell` helpfully (?) sets any embedded image views' `highlighted` property, it's particularly annoying there.
