### PR TITLE
Allow FLLumberjackIntegrationEnabled and FLDebugLoggingEnabled to be configured externally

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
@@ -17,9 +17,14 @@
 
 // Logging
 // If set to 0, disables integration with CocoaLumberjack Logger (only matters if CocoaLumberjack is installed).
-#define FLLumberjackIntegrationEnabled 1
+#ifndef FLLumberjackIntegrationEnabled
+    #define FLLumberjackIntegrationEnabled 1
+#endif
+
 // If set to 1, enables NSLog logging (only matters #if DEBUG -- never for release builds).
-#define FLDebugLoggingEnabled 0
+#ifndef FLDebugLoggingEnabled
+    #define FLDebugLoggingEnabled 0
+#endif
 
 
 //


### PR DESCRIPTION
The purpose of this PR is that it will allow a project to include FLAnimatedImage to externally define
`FLDebugLoggingEnabled` and `FLLumberjackIntegrationEnabled` via compilation flags, without source changes. This is useful when using FLAnimatedImage as a Cocoapod, for instance.
See https://github.com/Flipboard/FLAnimatedImage/issues/44 for context.

The code works for all projects without any changes.
