### PR TITLE
Avoiding costly CGImage creation during FLAnimatedImage initialization?

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
@@ -32,6 +32,7 @@
 
 @property (nonatomic, strong, readonly) UIImage *posterImage; // Guaranteed to be loaded; usually equivalent to `-imageLazilyCachedAtIndex:0`
 @property (nonatomic, assign, readonly) CGSize size; // The `.posterImage`'s `.size`
+@property (nonatomic, assign, readonly) NSUInteger posterImageFrameIndex; // Index of always-available poster image; never changes
 
 @property (nonatomic, assign, readonly) NSUInteger loopCount; // 0 means repeating the animation indefinitely
 @property (nonatomic, strong, readonly) NSArray *delayTimes; // Of type `NSTimeInterval` boxed in `NSNumber`s
@@ -43,6 +44,7 @@
 // Intended to be called from main thread synchronously; will return immediately.
 // If the result isn't cached, will return `nil`; the caller should then pause playback, not increment frame counter and keep polling.
 // After an initial loading time, depending on `frameCacheSize`, frames should be available immediately from the cache.
+// If the frame is corrupt, returns `NSNull`.
 - (UIImage *)imageLazilyCachedAtIndex:(NSUInteger)index;
 
 // Pass either a `UIImage` or an `FLAnimatedImage` and get back its size

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -51,7 +51,7 @@
         _animatedImage = animatedImage;
         
         self.currentFrame = animatedImage.posterImage;
-        self.currentFrameIndex = 0;
+        self.currentFrameIndex = animatedImage.posterImageFrameIndex;
         if (animatedImage.loopCount > 0) {
             self.loopCountdown = animatedImage.loopCount;
         } else {
@@ -240,11 +240,15 @@
     // If we have a nil image, don't update the view nor playhead.
     UIImage *image = [self.animatedImage imageLazilyCachedAtIndex:self.currentFrameIndex];
     if (image) {
-        FLLogVerbose(@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
-        self.currentFrame = image;
-        if (self.needsDisplayWhenImageBecomesAvailable) {
-            [self.layer setNeedsDisplay];
-            self.needsDisplayWhenImageBecomesAvailable = NO;
+        
+        // NSNull comes back when the frame is corrupt, so let's only show valid frames.
+        if ([image isKindOfClass:[UIImage class]]) {
+            FLLogVerbose(@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
+            self.currentFrame = image;
+            if (self.needsDisplayWhenImageBecomesAvailable) {
+                [self.layer setNeedsDisplay];
+                self.needsDisplayWhenImageBecomesAvailable = NO;
+            }
         }
         
         self.accumulator += displayLink.duration;
@@ -260,7 +264,7 @@
                     [self stopAnimating];
                     return;
                 }
-                self.currentFrameIndex = 0;
+                self.currentFrameIndex = self.animatedImage.posterImageFrameIndex;
             }
             // Calling `-setNeedsDisplay` will just paint the current frame, not the new frame that we may have moved to.
             // Instead, set `needsDisplayWhenImageBecomesAvailable` to `YES` -- this will paint the new image once loaded.


### PR DESCRIPTION
Hello! I'm curious about some behaviour in the initializer of FLAnimatedImage. At the moment it's [line 203 of FLAnimatedImage.m](https://github.com/Flipboard/FLAnimatedImage/blob/master/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m#L203), wherein a CGImage is created for each frame in the CGImageSource.

I'm guessing the idea here was to drop frames that aren't going to display anyway, and adjusting the timings appropriately. That makes sense to me. Decoding the first (working) frame for use as a "poster image" and for buffer size calculations also makes sense to me.

However, CGImageSourceCreateImageAtIndex is a costly operation, and it would be excellent to avoid it in the cases where the created CGImage isn't actually used. Not only does it feel wasteful (as the frames will be decoded once again during playback), it makes FLAnimatedImage initialization much slower than maybe it needs to be. If my guesses above are correct, I think we can speed things up tremendously.

Are my guesses here correct? I'm happy to poke around and maybe open a pull request, but I want to make sure I'm not missing anything.