### PR TITLE
FLAnimatedImage low memory notification warning crasher fixes

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -76,15 +76,41 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 // The actual type of the object is `FLWeakProxy`.
 @property (nonatomic, strong, readonly) FLAnimatedImage *weakProxy;
 
-// The weak self is used to prevent handling memory warning notifications (on the main thread),
-// when the object already entered dealloc (on a background thread) and hence would crash there.
-// We leverage the fact that the weak system guarantees to nil-out this reference before entering dealloc.
-@property (nonatomic, weak, readonly) FLAnimatedImage *weakSelf;
-
 @end
 
 
+// For dispatching memory warnings
+static NSHashTable *allAnimatedImagesWeak;
+
 @implementation FLAnimatedImage
+
++ (void)initialize
+{
+    if (self == [FLAnimatedImage class]) {
+        // UIKit memory warning notification handler shared by all of the instances
+        allAnimatedImagesWeak = [NSHashTable weakObjectsHashTable];
+        
+        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(NSNotification *note){
+            // UIKit notifications are posted on the main thread. didReceiveMemoryWarning: is expecting the main run loop, and we don't lock on allAnimatedImagesWeak
+            NSAssert([NSThread isMainThread], @"recevied memory warning on non-main thread");
+            // Get a strong reference to all of the images. If an instance is returned in this array, it is still live and has not entered dealloc.
+            NSArray *images;
+            @synchronized(allAnimatedImagesWeak) {      // FLAnimatedImages can be created on any thread
+                images = [[allAnimatedImagesWeak allObjects] copy];
+            }
+            // Now issue notifications to all of the images while holding a strong reference to them
+            [images makeObjectsPerformSelector:@selector(didReceiveMemoryWarning:) withObject:note];
+        }];
+    }
+}
+
++ (void)registerInstanceOfClassForMemoryWarnings:(FLAnimatedImage *)animatedImage
+{
+    // Add this instance to the weak table for memory notifications. The NSHashTable will clean up after itself when we're gone.
+    @synchronized(allAnimatedImagesWeak) {      // FLAnimatedImages can be created on any thread
+        [allAnimatedImagesWeak addObject:animatedImage];
+    }
+}
 
 #pragma mark - Accessors
 #pragma mark Public
@@ -314,10 +340,9 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
         
         // See the property declarations for descriptions.
         _weakProxy = (id)[FLWeakProxy weakProxyForObject:self];
-        _weakSelf = self;
         
-        // System Memory Warnings Notification Handler
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+        // Register for memory notifications
+        [[self class] registerInstanceOfClassForMemoryWarnings:self];
     }
     return self;
 }
@@ -332,8 +357,6 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
     if (_weakProxy) {
         [NSObject cancelPreviousPerformRequestsWithTarget:_weakProxy];
     }
@@ -597,12 +620,6 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 
 - (void)didReceiveMemoryWarning:(NSNotification *)notification
 {
-    // Bail when the weak reference to self is nil'ed out by the weak system.
-    // This indicates that we're already being deallocated on another thread and shouldn't do anymore work here.
-    if (!self.weakSelf) {
-        return;
-    }
-    
     self.memoryWarningCount++;
     
     // If we were about to grow larger, but got rapped on our knuckles by the system again, cancel.


### PR DESCRIPTION
This change uses an NSHashTable to prevent deallocation races that are causing occasional crashes when memory warnings fire. The FLAnimatedImage objects are being released on background threads (intended) as they are used in background queues. There is a race with the NSNotificationCenter callouts, as even though we check in the first line didRecieveMemoryWarning: if we have been deallocated, this doesn't prevent deallocation further in the method as we aren't referenced strongly by NSNotificationCenter (which isn't complied in ARC btw.) This is essentially because NSNotificationCenter does not retain the objects it is notifying during it's callouts, which is arguably correct behavior since NSNotificationCenter doesn't retain it's objects when registering to prevent retain cycles. Rolling our own notifier with NSHashTable allows us to fix this.

Note that FLAnimatedImages can be created on any thread, so the hash table must be locked.