### PR TITLE
Fix DEBUG definition warning

### DIFF
--- a/FLAnimatedImageDemo.xcodeproj/project.pbxproj
+++ b/FLAnimatedImageDemo.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = FLAnimatedImageDemo;
 				TARGETED_DEVICE_FAMILY = 2;
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -342,6 +343,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = FLAnimatedImageDemo;
 				TARGETED_DEVICE_FAMILY = 2;
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/FLAnimatedImageDemo/DebugView.h
+++ b/FLAnimatedImageDemo/DebugView.h
@@ -18,7 +18,7 @@ typedef NS_ENUM(NSUInteger, DebugViewStyle) {
 
 
 @interface DebugView : UIView
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 <FLAnimatedImageDebugDelegate,
 FLAnimatedImageViewDebugDelegate>
 #endif

--- a/FLAnimatedImageDemo/DebugView.m
+++ b/FLAnimatedImageDemo/DebugView.m
@@ -126,7 +126,7 @@
 }
 
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 #pragma mark - FLAnimatedImageDebugDelegate
 
 - (void)debug_animatedImage:(FLAnimatedImage *)animatedImage didUpdateCachedFrames:(NSIndexSet *)indexesOfFramesInCache

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
@@ -12,7 +12,7 @@
 // Allow user classes conveniently just importing one header.
 #import "FLAnimatedImageView.h"
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 @protocol FLAnimatedImageDebugDelegate;
 #endif
 
@@ -70,7 +70,7 @@
 
 @property (nonatomic, strong, readonly) NSData *data; // The data the receiver was initialized with; read-only
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 // Only intended to report internal state for debugging
 @property (nonatomic, weak) id<FLAnimatedImageDebugDelegate> debug_delegate;
 @property (nonatomic, strong) NSMutableDictionary *debug_info; // To track arbitrary data (e.g. original URL, loading durations, cache hits, etc.)
@@ -86,7 +86,7 @@
 @end
 
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 @protocol FLAnimatedImageDebugDelegate <NSObject>
 
 @optional

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -375,7 +375,7 @@ static NSHashTable *allAnimatedImagesWeak;
     
     // Remember requested frame index, this influences what we should cache next.
     self.requestedFrameIndex = index;
-#if DEBUG
+#if defined(DEBUG) && DEBUG
     if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImage:didRequestCachedFrame:)]) {
         [self.debug_delegate debug_animatedImage:self didRequestCachedFrame:index];
     }
@@ -438,11 +438,11 @@ static NSHashTable *allAnimatedImagesWeak;
         void (^frameRangeBlock)(NSRange, BOOL *) = ^(NSRange range, BOOL *stop) {
             // Iterate through contiguous indexes; can be faster than `enumerateIndexesInRange:options:usingBlock:`.
             for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
-#if DEBUG
+#if defined(DEBUG) && DEBUG
                 CFTimeInterval predrawBeginTime = CACurrentMediaTime();
 #endif
                 UIImage *image = [weakSelf predrawnImageAtIndex:i];
-#if DEBUG
+#if defined(DEBUG) && DEBUG
                 CFTimeInterval predrawDuration = CACurrentMediaTime() - predrawBeginTime;
                 CFTimeInterval slowdownDuration = 0.0;
                 if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImagePredrawingSlowdownFactor:)]) {
@@ -459,7 +459,7 @@ static NSHashTable *allAnimatedImagesWeak;
                         weakSelf.cachedFrames[i] = image;
                         [weakSelf.cachedFrameIndexes addIndex:i];
                         [weakSelf.requestedFrameIndexes removeIndex:i];
-#if DEBUG
+#if defined(DEBUG) && DEBUG
                         if ([weakSelf.debug_delegate respondsToSelector:@selector(debug_animatedImage:didUpdateCachedFrames:)]) {
                             [weakSelf.debug_delegate debug_animatedImage:weakSelf didUpdateCachedFrames:weakSelf.cachedFrameIndexes];
                         }
@@ -565,7 +565,7 @@ static NSHashTable *allAnimatedImagesWeak;
                 [self.cachedFrameIndexes removeIndex:i];
                 self.cachedFrames[i] = [NSNull null];
                 // Note: Don't `CGImageSourceRemoveCacheAtIndex` on the image source for frames that we don't want cached any longer to maintain O(1) time access.
-#if DEBUG
+#if defined(DEBUG) && DEBUG
                 if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImage:didUpdateCachedFrames:)]) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [self.debug_delegate debug_animatedImage:self didUpdateCachedFrames:self.cachedFrameIndexes];

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.h
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.h
@@ -28,7 +28,7 @@
 @property (nonatomic, strong, readonly) UIImage *currentFrame;
 @property (nonatomic, assign, readonly) NSUInteger currentFrameIndex;
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 // Only intended to report internal state for debugging
 @property (nonatomic, weak) id<FLAnimatedImageViewDebugDelegate> debug_delegate;
 #endif
@@ -36,7 +36,7 @@
 @end
 
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 @protocol FLAnimatedImageViewDebugDelegate <NSObject>
 
 @optional

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -271,7 +271,7 @@
         }
     } else {
         FLLogDebug(@"Waiting for frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
-#if DEBUG
+#if defined(DEBUG) && DEBUG
         if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImageView:waitingForFrame:duration:)]) {
             [self.debug_delegate debug_animatedImageView:self waitingForFrame:self.currentFrameIndex duration:(NSTimeInterval)self.displayLink.duration];
         }

--- a/FLAnimatedImageDemo/RootViewController.m
+++ b/FLAnimatedImageDemo/RootViewController.m
@@ -79,7 +79,7 @@
             self.imageView2.animatedImage = animatedImage2;
             
             // Set up debug UI for image 2
-#if DEBUG
+#if defined(DEBUG) && DEBUG
             self.imageView2.debug_delegate = self.debugView2;
             animatedImage2.debug_delegate = self.debugView2;
 #endif
@@ -108,7 +108,7 @@
             self.imageView3.animatedImage = animatedImage3;
             
             // Set up debug UI for image 3
-#if DEBUG
+#if defined(DEBUG) && DEBUG
             self.imageView3.debug_delegate = self.debugView3;
             animatedImage3.debug_delegate = self.debugView3;
 #endif
@@ -123,7 +123,7 @@
     
     
     // Setting the delegates is for the debug UI in this demo only and is usually not needed.
-#if DEBUG
+#if defined(DEBUG) && DEBUG
     self.imageView1.debug_delegate = self.debugView1;
     animatedImage1.debug_delegate = self.debugView1;
 #endif


### PR DESCRIPTION
Vanilla iOS projects define `DEBUG` to be 1 in the Debug build configuration, and don't define `DEBUG` at all in the Release build configuration. That means that if you make a release build `DEBUG` is implicitly 0, but if you turn on the `-Wundef` warning flag you'll get warnings about this implicit value.

![screen shot 2015-02-24 at 11 22 40 am](https://cloud.githubusercontent.com/assets/522951/6357208/79f179de-bc17-11e4-89d6-3d69994b6e80.png)

This pull request explicitly makes sure both that `DEBUG` is defined and that its value evaluates to true.