### PR TITLE
Corrupt frame fixup

### DIFF
--- a/FLAnimatedImageDemo/DebugView.m
+++ b/FLAnimatedImageDemo/DebugView.m
@@ -141,7 +141,7 @@
     if (self.frameCacheView.requestedFrameIndex != index) {
         self.frameCacheView.requestedFrameIndex = index;
         
-        NSTimeInterval delayTime = [self.image.delayTimes[index] doubleValue];
+        NSTimeInterval delayTime = [self.image.delayTimesForIndexes[@(index)] doubleValue];
         CGRect frameRect = ((UIView *)self.frameCacheView.subviews[index]).frame;
         
         CGPoint playheadStartCenter = CGPointMake(self.frameCacheView.frame.origin.x + frameRect.origin.x, self.playheadView.center.y);

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h
@@ -50,7 +50,7 @@
 @property (nonatomic, assign, readonly) CGSize size; // The `.posterImage`'s `.size`
 
 @property (nonatomic, assign, readonly) NSUInteger loopCount; // 0 means repeating the animation indefinitely
-@property (nonatomic, strong, readonly) NSArray *delayTimes; // Of type `NSTimeInterval` boxed in `NSNumber`s
+@property (nonatomic, strong, readonly) NSDictionary *delayTimesForIndexes; // Of type `NSTimeInterval` boxed in `NSNumber`s
 @property (nonatomic, assign, readonly) NSUInteger frameCount; // Number of valid frames; equal to `[.delayTimes count]`
 
 @property (nonatomic, assign, readonly) NSUInteger frameCacheSizeCurrent; // Current size of intelligently chosen buffer window; can range in the interval [1..frameCount]

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 @property (nonatomic, assign) NSUInteger frameCacheSizeMaxInternal; // Allow to cap the cache size e.g. when memory warnings occur; 0 means no specific limit (default)
 @property (nonatomic, assign) NSUInteger requestedFrameIndex; // Most recently requested frame index
 @property (nonatomic, assign, readonly) NSUInteger posterImageFrameIndex; // Index of non-purgable poster image; never changes
-@property (nonatomic, strong, readonly) NSMutableArray *cachedFrames; // Uncached frame indexes hold `NSNull`
+@property (nonatomic, strong, readonly) NSMutableDictionary *cachedFramesForIndexes;
 @property (nonatomic, strong, readonly) NSMutableIndexSet *cachedFrameIndexes; // Indexes of cached frames
 @property (nonatomic, strong, readonly) NSMutableIndexSet *requestedFrameIndexes; // Indexes of frames that are currently produced in the background
 @property (nonatomic, strong, readonly) NSIndexSet *allFramesIndexSet; // Default index set with the full range of indexes; never changes
@@ -189,8 +189,7 @@ static NSHashTable *allAnimatedImagesWeak;
         _data = data;
         
         // Initialize internal data structures
-        // We'll fill in the initial `NSNull` values below, when we loop through all frames.
-        _cachedFrames = [[NSMutableArray alloc] init];
+        _cachedFramesForIndexes = [[NSMutableDictionary alloc] init];
         _cachedFrameIndexes = [[NSMutableIndexSet alloc] init];
         _requestedFrameIndexes = [[NSMutableIndexSet alloc] init];
 
@@ -239,12 +238,8 @@ static NSHashTable *allAnimatedImagesWeak;
                         _size = _posterImage.size;
                         // Remember index of poster image so we never purge it; also add it to the cache.
                         _posterImageFrameIndex = i;
-                        self.cachedFrames[self.posterImageFrameIndex] = self.posterImage;
+                        [self.cachedFramesForIndexes setObject:self.posterImage forKey:@(self.posterImageFrameIndex)];
                         [self.cachedFrameIndexes addIndex:self.posterImageFrameIndex];
-                    } else {
-                        // Placeholder indicates that we don't have a cached frame.
-                        // We use an array instead of a dictionary for slightly faster access.
-                        self.cachedFrames[i] = [NSNull null];
                     }
                     
                     // Get `DelayTime`
@@ -397,12 +392,8 @@ static NSHashTable *allAnimatedImagesWeak;
         }
     }
     
-    // Get the specified image. Watch out for `NSNull` placeholders.
-    UIImage *image = nil;
-    id tryImage = self.cachedFrames[index];
-    if ([tryImage isKindOfClass:[UIImage class]]) {
-        image = tryImage;
-    }
+    // Get the specified image.
+    UIImage *image = self.cachedFramesForIndexes[@(index)];
     
     // Purge if needed based on the current playhead position.
     [self purgeFrameCacheIfNeeded];
@@ -456,7 +447,7 @@ static NSHashTable *allAnimatedImagesWeak;
                 // The benefits of having the first frames as quick as possible outweigh building up a buffer to cope with potential hiccups when the CPU suddenly gets busy.
                 if (image && weakSelf) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        weakSelf.cachedFrames[i] = image;
+                        weakSelf.cachedFramesForIndexes[@(i)] = image;
                         [weakSelf.cachedFrameIndexes addIndex:i];
                         [weakSelf.requestedFrameIndexes removeIndex:i];
 #if defined(DEBUG) && DEBUG
@@ -563,7 +554,7 @@ static NSHashTable *allAnimatedImagesWeak;
             // Iterate through contiguous indexes; can be faster than `enumerateIndexesInRange:options:usingBlock:`.
             for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
                 [self.cachedFrameIndexes removeIndex:i];
-                self.cachedFrames[i] = [NSNull null];
+                [self.cachedFramesForIndexes removeObjectForKey:@(i)];
                 // Note: Don't `CGImageSourceRemoveCacheAtIndex` on the image source for frames that we don't want cached any longer to maintain O(1) time access.
 #if defined(DEBUG) && DEBUG
                 if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImage:didUpdateCachedFrames:)]) {

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -224,7 +224,7 @@ static NSHashTable *allAnimatedImagesWeak;
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);
-        NSMutableArray *delayTimesMutable = [NSMutableArray arrayWithCapacity:imageCount];
+        NSMutableDictionary *delayTimesForIndexesMutable = [NSMutableDictionary dictionaryWithCapacity:imageCount];
         for (size_t i = 0; i < imageCount; i++) {
             CGImageRef frameImageRef = CGImageSourceCreateImageAtIndex(_imageSource, i, NULL);
             if (frameImageRef) {
@@ -272,7 +272,7 @@ static NSHashTable *allAnimatedImagesWeak;
                             delayTime = @(kDelayTimeIntervalDefault);
                         } else {
                             FLLogInfo(@"Falling back to preceding delay time for frame %zu %@ because none found in GIF properties %@", i, frameImage, frameProperties);
-                            delayTime = delayTimesMutable[i - 1];
+                            delayTime = delayTimesForIndexesMutable[@(i - 1)];
                         }
                     }
                     // Support frame delays as low as `kDelayTimeIntervalMinimum`, with anything below being rounded up to `kDelayTimeIntervalDefault` for legacy compatibility.
@@ -283,7 +283,7 @@ static NSHashTable *allAnimatedImagesWeak;
                         FLLogInfo(@"Rounding frame %zu's `delayTime` from %f up to default %f (minimum supported: %f).", i, [delayTime floatValue], kDelayTimeIntervalDefault, kDelayTimeIntervalMinimum);
                         delayTime = @(kDelayTimeIntervalDefault);
                     }
-                    delayTimesMutable[i] = delayTime;
+                    delayTimesForIndexesMutable[@(i)] = delayTime;
                 } else {
                     FLLogInfo(@"Dropping frame %zu because valid `CGImageRef` %@ did result in `nil`-`UIImage`.", i, frameImageRef);
                 }
@@ -292,8 +292,8 @@ static NSHashTable *allAnimatedImagesWeak;
                 FLLogInfo(@"Dropping frame %zu because failed to `CGImageSourceCreateImageAtIndex` with image source %@", i, _imageSource);
             }
         }
-        _delayTimes = [delayTimesMutable copy];
-        _frameCount = [_delayTimes count];
+        _delayTimesForIndexes = [delayTimesForIndexesMutable copy];
+        _frameCount = imageCount;
         
         if (self.frameCount == 0) {
             FLLogInfo(@"Failed to create any valid frames for GIF with properties %@", imageProperties);

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -240,43 +240,48 @@
         return;
     }
     
-    // If we have a nil image, don't update the view nor playhead.
-    UIImage *image = [self.animatedImage imageLazilyCachedAtIndex:self.currentFrameIndex];
-    if (image) {
-        FLLogVerbose(@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
-        self.currentFrame = image;
-        if (self.needsDisplayWhenImageBecomesAvailable) {
-            [self.layer setNeedsDisplay];
-            self.needsDisplayWhenImageBecomesAvailable = NO;
-        }
-        
-        self.accumulator += displayLink.duration;
-        
-        // While-loop first inspired by & good Karma to: https://github.com/ondalabs/OLImageView/blob/master/OLImageView.m
-        NSTimeInterval delayTime = [[self.animatedImage.delayTimesForIndexes objectForKey:@(self.currentFrameIndex)] floatValue];
-        while (self.accumulator >= delayTime) {
-            self.accumulator -= delayTime;
-            self.currentFrameIndex++;
-            if (self.currentFrameIndex >= self.animatedImage.frameCount) {
-                // If we've looped the number of times that this animated image describes, stop looping.
-                self.loopCountdown--;
-                if (self.loopCountdown == 0) {
-                    [self stopAnimating];
-                    return;
-                }
-                self.currentFrameIndex = 0;
+    NSTimeInterval delayTime = [[self.animatedImage.delayTimesForIndexes objectForKey:@(self.currentFrameIndex)] floatValue];
+    if (delayTime > 0.0) {
+        // If we have a nil image, don't update the view nor playhead.
+        UIImage *image = [self.animatedImage imageLazilyCachedAtIndex:self.currentFrameIndex];
+        if (image) {
+            FLLogVerbose(@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
+            self.currentFrame = image;
+            if (self.needsDisplayWhenImageBecomesAvailable) {
+                [self.layer setNeedsDisplay];
+                self.needsDisplayWhenImageBecomesAvailable = NO;
             }
-            // Calling `-setNeedsDisplay` will just paint the current frame, not the new frame that we may have moved to.
-            // Instead, set `needsDisplayWhenImageBecomesAvailable` to `YES` -- this will paint the new image once loaded.
-            self.needsDisplayWhenImageBecomesAvailable = YES;
+            
+            self.accumulator += displayLink.duration;
+            
+            // While-loop first inspired by & good Karma to: https://github.com/ondalabs/OLImageView/blob/master/OLImageView.m
+            while (self.accumulator >= delayTime) {
+                self.accumulator -= delayTime;
+                self.currentFrameIndex++;
+                if (self.currentFrameIndex >= self.animatedImage.frameCount) {
+                    // If we've looped the number of times that this animated image describes, stop looping.
+                    self.loopCountdown--;
+                    if (self.loopCountdown == 0) {
+                        [self stopAnimating];
+                        return;
+                    }
+                    self.currentFrameIndex = 0;
+                }
+                // Calling `-setNeedsDisplay` will just paint the current frame, not the new frame that we may have moved to.
+                // Instead, set `needsDisplayWhenImageBecomesAvailable` to `YES` -- this will paint the new image once loaded.
+                self.needsDisplayWhenImageBecomesAvailable = YES;
+            }
+        } else {
+            FLLogDebug(@"Waiting for frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
+#if defined(DEBUG) && DEBUG
+            if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImageView:waitingForFrame:duration:)]) {
+                [self.debug_delegate debug_animatedImageView:self waitingForFrame:self.currentFrameIndex duration:(NSTimeInterval)self.displayLink.duration];
+            }
+#endif
         }
     } else {
-        FLLogDebug(@"Waiting for frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
-#if defined(DEBUG) && DEBUG
-        if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImageView:waitingForFrame:duration:)]) {
-            [self.debug_delegate debug_animatedImageView:self waitingForFrame:self.currentFrameIndex duration:(NSTimeInterval)self.displayLink.duration];
-        }
-#endif
+        // If there's no delay time simply advance to the next frame.
+        self.currentFrameIndex++;
     }
 }
 

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -240,8 +240,9 @@
         return;
     }
     
-    NSTimeInterval delayTime = [[self.animatedImage.delayTimesForIndexes objectForKey:@(self.currentFrameIndex)] floatValue];
-    if (delayTime > 0.0) {
+    NSNumber *delayTimeNumber = [self.animatedImage.delayTimesForIndexes objectForKey:@(self.currentFrameIndex)];
+    if (delayTimeNumber) {
+        NSTimeInterval delayTime = [delayTimeNumber floatValue];
         // If we have a nil image, don't update the view nor playhead.
         UIImage *image = [self.animatedImage imageLazilyCachedAtIndex:self.currentFrameIndex];
         if (image) {

--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m
@@ -253,8 +253,9 @@
         self.accumulator += displayLink.duration;
         
         // While-loop first inspired by & good Karma to: https://github.com/ondalabs/OLImageView/blob/master/OLImageView.m
-        while (self.accumulator >= [self.animatedImage.delayTimes[self.currentFrameIndex] floatValue]) {
-            self.accumulator -= [self.animatedImage.delayTimes[self.currentFrameIndex] floatValue];
+        NSTimeInterval delayTime = [[self.animatedImage.delayTimesForIndexes objectForKey:@(self.currentFrameIndex)] floatValue];
+        while (self.accumulator >= delayTime) {
+            self.accumulator -= delayTime;
             self.currentFrameIndex++;
             if (self.currentFrameIndex >= self.animatedImage.frameCount) {
                 // If we've looped the number of times that this animated image describes, stop looping.

--- a/FLAnimatedImageDemo/FrameCacheView.m
+++ b/FLAnimatedImageDemo/FrameCacheView.m
@@ -98,11 +98,16 @@
 
 - (void)updateSubviewFrames
 {
-    NSTimeInterval delayTimesTotal = [[self.image.delayTimes valueForKeyPath:@"@sum.self"] doubleValue];
+    __block NSTimeInterval delayTimesTotal = 0.0;
+    [self.image.delayTimesForIndexes enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        if ([obj isKindOfClass:[NSNumber class]]) {
+            delayTimesTotal += [(NSNumber *)obj doubleValue];
+        }
+    }];
     CGFloat x = 0.0;
     NSUInteger i = 0;
     for (UIView *subview in self.subviews) {
-        CGFloat width = self.bounds.size.width * [self.image.delayTimes[i] doubleValue] / delayTimesTotal + subview.layer.borderWidth;
+        CGFloat width = self.bounds.size.width * [self.image.delayTimesForIndexes[@(i)] doubleValue] / delayTimesTotal + subview.layer.borderWidth;
         CGRect frame = CGRectMake(x, 0.0, width, self.bounds.size.height);
         
         subview.frame = frame;


### PR DESCRIPTION
This pull request resolves an issue causing images with corrupt frames to crash `FLAnimatedImage`, specifically images like [this](https://dl.dropboxusercontent.com/s/duveng0hqjc263t/scotus-gay-marriage-decision%20copy-6-26-2015.gif). The reason for this crash was that frames were attempting to be injected into the `cachedFrames` at indexes that were out of bounds. As a simplification, I converted `cachedFrames` and `delayTimes` to dictionaries, which are more tolerant of nulls. I also made it so that frames lacking delays are skipped in https://github.com/Flipboard/FLAnimatedImage/commit/178b714357fef62c38c7aec5ba65d41ca2cf069e.

A simple way to test this is to change the URL on [this line](https://github.com/Flipboard/FLAnimatedImage/blob/master/FLAnimatedImageDemo/RootViewController.m#L103) to https://dl.dropboxusercontent.com/s/duveng0hqjc263t/scotus-gay-marriage-decision%20copy-6-26-2015.gif.