### PR TITLE
Fix DEBUG definition warning part 2

### DIFF
--- a/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m
@@ -20,7 +20,7 @@
 #define MEGABYTE (1024 * 1024)
 
 #if FLLumberjackIntegrationEnabled && defined(FLLumberjackAvailable)
-    #if DEBUG
+    #if defined(DEBUG) && DEBUG
         #if defined(LOG_LEVEL_DEBUG) // CocoaLumberjack 1.x
             int flAnimatedImageLogLevel = LOG_LEVEL_DEBUG;
         #else // CocoaLumberjack 2.x


### PR DESCRIPTION
This pull request checks for both the definition and value of a macro to prevent -Wundef from generating a warning in FLAnimatedImage's logging support code. I missed this in https://github.com/Flipboard/FLAnimatedImage/pull/66, which enabled -Wundef and added prevention for the warnings it generates.