### PR TITLE
Allows to customise the mode the run loop

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.h
+++ b/FLAnimatedImage/FLAnimatedImageView.h
@@ -29,4 +29,8 @@
 @property (nonatomic, strong, readonly) UIImage *currentFrame;
 @property (nonatomic, assign, readonly) NSUInteger currentFrameIndex;
 
+// The animation runloop mode. Enables playback during scrolling by allowing timer events (i.e. animation) with NSRunLoopCommonModes.
+// To keep scrolling smooth on single-core devices such as iPhone 3GS/4 and iPod Touch 4th gen, the default run loop mode is NSDefaultRunLoopMode. Otherwise, the default is NSDefaultRunLoopMode.
+@property (nonatomic, copy) NSString *runLoopMode;
+
 @end

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -43,6 +43,18 @@
 @implementation FLAnimatedImageView
 @synthesize runLoopMode = _runLoopMode;
 
+#pragma mark - Initializers
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.runLoopMode = [[self class] defaultRunLoopMode];
+    }
+    return self;
+}
+
+
 #pragma mark - Accessors
 #pragma mark Public
 
@@ -260,22 +272,11 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
 - (void)setRunLoopMode:(NSString *)runLoopMode
 {
     if (![@[NSDefaultRunLoopMode, NSRunLoopCommonModes] containsObject:runLoopMode]) {
-        [NSException raise:@"Invalid argument: Only NSDefaultRunLoopMode and NSRunLoopCommonModes are expected!" format:@""];
+        NSAssert(NO, @"Invalid run loop mode: %@", runLoopMode);
+        _runLoopMode = [[self class] defaultRunLoopMode];
+    } else {
+        _runLoopMode = runLoopMode;
     }
-    
-    _runLoopMode = [runLoopMode copy];
-}
-
-- (NSString *)runLoopMode
-{
-    NSString *mode = NSDefaultRunLoopMode;
-    
-    // Key off `activeProcessorCount` (as opposed to `processorCount`) since the system could shut down cores in certain situations.
-    if ([NSProcessInfo processInfo].activeProcessorCount > 1) {
-        mode = NSRunLoopCommonModes;
-    }
-    
-    return _runLoopMode ? : mode;
 }
 
 - (void)stopAnimating
@@ -380,6 +381,12 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
     } else {
         self.currentFrameIndex++;
     }
+}
+
++ (NSString *)defaultRunLoopMode
+{
+    // Key off `activeProcessorCount` (as opposed to `processorCount`) since the system could shut down cores in certain situations.
+    return [NSProcessInfo processInfo].activeProcessorCount > 1 ? NSRunLoopCommonModes : NSDefaultRunLoopMode;
 }
 
 


### PR DESCRIPTION
Sometimes, it's not required to continue the animation while scrolling, specially when there are many GIF images displayed. A scrollable 9x12 grid of animated GIF tends to drops a few frames, specially when scrolling very fast. Pausing the animation allows a smoother scrolling XP. 💪📱

Default is still `NSRunLoopCommonModes`, when available. 