### PR TITLE
Logging decouple

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImage/FLAnimatedImage.h
@@ -66,6 +66,21 @@
 
 @end
 
+typedef NS_ENUM(NSUInteger, FLLogLevel) {
+    FLLogLevelError,
+    FLLogLevelWarn,
+    FLLogLevelInfo,
+    FLLogLevelDebug,
+    FLLogLevelVerbose
+};
+
+@interface FLAnimatedImage (Logging)
+
++ (void)setLogBlock:(void (^)(NSString *logString, FLLogLevel logLevel))logBlock;
++ (void)logString:(NSString *)logString withLevel:(FLLogLevel)level;
+
+@end
+
 
 @interface FLWeakProxy : NSProxy
 
@@ -85,17 +100,3 @@
 
 @end
 #endif
-
-
-#if FLDebugLoggingEnabled && DEBUG
-    // CocoaLumberjack is disabled or not available, but we want to fallback to regular logging (debug builds only).
-    #define FLLog(...) NSLog(__VA_ARGS__)
-#else
-    // No logging at all.
-    #define FLLog(...) ((void)0)
-#endif
-#define FLLogError(...)   FLLog(__VA_ARGS__)
-#define FLLogWarn(...)    FLLog(__VA_ARGS__)
-#define FLLogInfo(...)    FLLog(__VA_ARGS__)
-#define FLLogDebug(...)   FLLog(__VA_ARGS__)
-#define FLLogVerbose(...) FLLog(__VA_ARGS__)

--- a/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImage/FLAnimatedImage.h
@@ -17,18 +17,6 @@
 #endif
 
 
-// Logging
-// If set to 0, disables integration with CocoaLumberjack Logger (only matters if CocoaLumberjack is installed).
-#ifndef FLLumberjackIntegrationEnabled
-    #define FLLumberjackIntegrationEnabled 1
-#endif
-
-// If set to 1, enables NSLog logging (only matters #if DEBUG -- never for release builds).
-#ifndef FLDebugLoggingEnabled
-    #define FLDebugLoggingEnabled 0
-#endif
-
-
 #ifndef NS_DESIGNATED_INITIALIZER
     #if __has_attribute(objc_designated_initializer)
         #define NS_DESIGNATED_INITIALIZER __attribute((objc_designated_initializer))
@@ -99,58 +87,15 @@
 #endif
 
 
-// Try to detect and import CocoaLumberjack in all scenarious (library versions, way of including it, CocoaPods versions, etc.).
-#if FLLumberjackIntegrationEnabled
-    #if defined(__has_include)
-        #if __has_include("<CocoaLumberjack/CocoaLumberjack.h>")
-            #import <CocoaLumberjack/CocoaLumberjack.h>
-        #elif __has_include("CocoaLumberjack.h")
-            #import "CocoaLumberjack.h"
-        #elif __has_include("<CocoaLumberjack/DDLog.h>")
-            #import <CocoaLumberjack/DDLog.h>
-        #elif __has_include("DDLog.h")
-            #import "DDLog.h"
-        #endif
-    #elif defined(COCOAPODS_POD_AVAILABLE_CocoaLumberjack) || defined(__POD_CocoaLumberjack)
-        #if COCOAPODS_VERSION_MAJOR_CocoaLumberjack == 2
-            #import <CocoaLumberjack/CocoaLumberjack.h>
-        #else
-            #import <CocoaLumberjack/DDLog.h>
-        #endif
-    #endif
-
-    #if defined(DDLogError) && defined(DDLogWarn) && defined(DDLogInfo) && defined(DDLogDebug) && defined(DDLogVerbose)
-        #define FLLumberjackAvailable
-    #endif
-#endif
-
-#if FLLumberjackIntegrationEnabled && defined(FLLumberjackAvailable)
-    // Use a custom, global (not per-file) log level for this library.
-    extern int flAnimatedImageLogLevel;
-    #if defined(LOG_OBJC_MAYBE) // CocoaLumberjack 1.x
-        #define FLLogError(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_ERROR,   flAnimatedImageLogLevel, LOG_FLAG_ERROR,   0, frmt, ##__VA_ARGS__)
-        #define FLLogWarn(frmt, ...)    LOG_OBJC_MAYBE(LOG_ASYNC_WARN,    flAnimatedImageLogLevel, LOG_FLAG_WARN,    0, frmt, ##__VA_ARGS__)
-        #define FLLogInfo(frmt, ...)    LOG_OBJC_MAYBE(LOG_ASYNC_INFO,    flAnimatedImageLogLevel, LOG_FLAG_INFO,    0, frmt, ##__VA_ARGS__)
-        #define FLLogDebug(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_DEBUG,   flAnimatedImageLogLevel, LOG_FLAG_DEBUG,   0, frmt, ##__VA_ARGS__)
-        #define FLLogVerbose(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_VERBOSE, flAnimatedImageLogLevel, LOG_FLAG_VERBOSE, 0, frmt, ##__VA_ARGS__)
-    #else // CocoaLumberjack 2.x
-        #define FLLogError(frmt, ...)   LOG_MAYBE(NO,                flAnimatedImageLogLevel, DDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-        #define FLLogWarn(frmt, ...)    LOG_MAYBE(LOG_ASYNC_ENABLED, flAnimatedImageLogLevel, DDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-        #define FLLogInfo(frmt, ...)    LOG_MAYBE(LOG_ASYNC_ENABLED, flAnimatedImageLogLevel, DDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-        #define FLLogDebug(frmt, ...)   LOG_MAYBE(LOG_ASYNC_ENABLED, flAnimatedImageLogLevel, DDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-        #define FLLogVerbose(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, flAnimatedImageLogLevel, DDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-    #endif
+#if FLDebugLoggingEnabled && DEBUG
+    // CocoaLumberjack is disabled or not available, but we want to fallback to regular logging (debug builds only).
+    #define FLLog(...) NSLog(__VA_ARGS__)
 #else
-    #if FLDebugLoggingEnabled && DEBUG
-        // CocoaLumberjack is disabled or not available, but we want to fallback to regular logging (debug builds only).
-        #define FLLog(...) NSLog(__VA_ARGS__)
-    #else
-        // No logging at all.
-        #define FLLog(...) ((void)0)
-    #endif
-    #define FLLogError(...)   FLLog(__VA_ARGS__)
-    #define FLLogWarn(...)    FLLog(__VA_ARGS__)
-    #define FLLogInfo(...)    FLLog(__VA_ARGS__)
-    #define FLLogDebug(...)   FLLog(__VA_ARGS__)
-    #define FLLogVerbose(...) FLLog(__VA_ARGS__)
+    // No logging at all.
+    #define FLLog(...) ((void)0)
 #endif
+#define FLLogError(...)   FLLog(__VA_ARGS__)
+#define FLLogWarn(...)    FLLog(__VA_ARGS__)
+#define FLLogInfo(...)    FLLog(__VA_ARGS__)
+#define FLLogDebug(...)   FLLog(__VA_ARGS__)
+#define FLLogVerbose(...) FLLog(__VA_ARGS__)

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -19,22 +19,6 @@
 
 #define MEGABYTE (1024 * 1024)
 
-#if FLLumberjackIntegrationEnabled && defined(FLLumberjackAvailable)
-    #if defined(DEBUG) && DEBUG
-        #if defined(LOG_LEVEL_DEBUG) // CocoaLumberjack 1.x
-            int flAnimatedImageLogLevel = LOG_LEVEL_DEBUG;
-        #else // CocoaLumberjack 2.x
-            int flAnimatedImageLogLevel = DDLogFlagDebug;
-        #endif
-    #else
-        #if defined(LOG_LEVEL_WARN) // CocoaLumberjack 1.x
-            int flAnimatedImageLogLevel = LOG_LEVEL_WARN;
-        #else // CocoaLumberjack 2.x
-            int flAnimatedImageLogLevel = DDLogFlagWarning;
-        #endif
-    #endif
-#endif
-
 
 // An animated image's data size (dimensions * frameCount) category; its value is the max allowed memory (in MB).
 // E.g.: A 100x200px GIF with 30 frames is ~2.3MB in our pixel format and would fall into the `FLAnimatedImageDataSizeCategoryAll` category.

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -149,7 +149,7 @@ static NSHashTable *allAnimatedImagesWeak;
 {
     FLAnimatedImage *animatedImage = [self initWithAnimatedGIFData:nil];
     if (!animatedImage) {
-        FLLogError(@"Use `-initWithAnimatedGIFData:` and supply the animated GIF data as an argument to initialize an object of type `FLAnimatedImage`.");
+        [FLAnimatedImage logString:@"Use `-initWithAnimatedGIFData:` and supply the animated GIF data as an argument to initialize an object of type `FLAnimatedImage`." withLevel:FLLogLevelError];
     }
     return animatedImage;
 }
@@ -160,7 +160,7 @@ static NSHashTable *allAnimatedImagesWeak;
     // Early return if no data supplied!
     BOOL hasData = ([data length] > 0);
     if (!hasData) {
-        FLLogError(@"No animated GIF data supplied.");
+        [FLAnimatedImage logString:@"No animated GIF data supplied." withLevel:FLLogLevelError];
         return nil;
     }
     
@@ -182,7 +182,7 @@ static NSHashTable *allAnimatedImagesWeak;
                                                    (__bridge CFDictionaryRef)@{(NSString *)kCGImageSourceShouldCache: @NO});
         // Early return on failure!
         if (!_imageSource) {
-            FLLogError(@"Failed to `CGImageSourceCreateWithData` for animated GIF data %@", data);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Failed to `CGImageSourceCreateWithData` for animated GIF data %@", data] withLevel:FLLogLevelError];
             return nil;
         }
         
@@ -190,7 +190,7 @@ static NSHashTable *allAnimatedImagesWeak;
         CFStringRef imageSourceContainerType = CGImageSourceGetType(_imageSource);
         BOOL isGIFData = UTTypeConformsTo(imageSourceContainerType, kUTTypeGIF);
         if (!isGIFData) {
-            FLLogError(@"Supplied data is of type %@ and doesn't seem to be GIF data %@", imageSourceContainerType, data);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Supplied data is of type %@ and doesn't seem to be GIF data %@", imageSourceContainerType, data] withLevel:FLLogLevelError];
             return nil;
         }
         
@@ -254,10 +254,10 @@ static NSHashTable *allAnimatedImagesWeak;
                     const NSTimeInterval kDelayTimeIntervalDefault = 0.1;
                     if (!delayTime) {
                         if (i == 0) {
-                            FLLogInfo(@"Falling back to default delay time for first frame %@ because none found in GIF properties %@", frameImage, frameProperties);
+                            [FLAnimatedImage logString:[NSString stringWithFormat:@"Falling back to default delay time for first frame %@ because none found in GIF properties %@", frameImage, frameProperties] withLevel:FLLogLevelInfo];
                             delayTime = @(kDelayTimeIntervalDefault);
                         } else {
-                            FLLogInfo(@"Falling back to preceding delay time for frame %zu %@ because none found in GIF properties %@", i, frameImage, frameProperties);
+                            [FLAnimatedImage logString:[NSString stringWithFormat:@"Falling back to preceding delay time for frame %zu %@ because none found in GIF properties %@", i, frameImage, frameProperties] withLevel:FLLogLevelInfo];
                             delayTime = delayTimesForIndexesMutable[@(i - 1)];
                         }
                     }
@@ -266,29 +266,29 @@ static NSHashTable *allAnimatedImagesWeak;
                     const NSTimeInterval kDelayTimeIntervalMinimum = 0.02;
                     // To support the minimum even when rounding errors occur, use an epsilon when comparing. We downcast to float because that's what we get for delayTime from ImageIO.
                     if ([delayTime floatValue] < ((float)kDelayTimeIntervalMinimum - FLT_EPSILON)) {
-                        FLLogInfo(@"Rounding frame %zu's `delayTime` from %f up to default %f (minimum supported: %f).", i, [delayTime floatValue], kDelayTimeIntervalDefault, kDelayTimeIntervalMinimum);
+                        [FLAnimatedImage logString:[NSString stringWithFormat:@"Rounding frame %zu's `delayTime` from %f up to default %f (minimum supported: %f).", i, [delayTime floatValue], kDelayTimeIntervalDefault, kDelayTimeIntervalMinimum] withLevel:FLLogLevelInfo];
                         delayTime = @(kDelayTimeIntervalDefault);
                     }
                     delayTimesForIndexesMutable[@(i)] = delayTime;
                 } else {
                     skippedFrameCount++;
-                    FLLogInfo(@"Dropping frame %zu because valid `CGImageRef` %@ did result in `nil`-`UIImage`.", i, frameImageRef);
+                    [FLAnimatedImage logString:[NSString stringWithFormat:@"Dropping frame %zu because valid `CGImageRef` %@ did result in `nil`-`UIImage`.", i, frameImageRef] withLevel:FLLogLevelInfo];
                 }
                 CFRelease(frameImageRef);
             } else {
                 skippedFrameCount++;
-                FLLogInfo(@"Dropping frame %zu because failed to `CGImageSourceCreateImageAtIndex` with image source %@", i, _imageSource);
+                [FLAnimatedImage logString:[NSString stringWithFormat:@"Dropping frame %zu because failed to `CGImageSourceCreateImageAtIndex` with image source %@", i, _imageSource] withLevel:FLLogLevelInfo];
             }
         }
         _delayTimesForIndexes = [delayTimesForIndexesMutable copy];
         _frameCount = imageCount;
         
         if (self.frameCount == 0) {
-            FLLogInfo(@"Failed to create any valid frames for GIF with properties %@", imageProperties);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Failed to create any valid frames for GIF with properties %@", imageProperties] withLevel:FLLogLevelInfo];
             return nil;
         } else if (self.frameCount == 1) {
             // Warn when we only have a single frame but return a valid GIF.
-            FLLogInfo(@"Created valid GIF but with only a single frame. Image properties: %@", imageProperties);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Created valid GIF but with only a single frame. Image properties: %@", imageProperties] withLevel:FLLogLevelInfo];
         } else {
             // We have multiple frames, rock on!
         }
@@ -352,7 +352,7 @@ static NSHashTable *allAnimatedImagesWeak;
     // Early return if the requested index is beyond bounds.
     // Note: We're comparing an index with a count and need to bail on greater than or equal to.
     if (index >= self.frameCount) {
-        FLLogWarn(@"Skipping requested frame %lu beyond bounds (total frame count: %lu) for animated image: %@", (unsigned long)index, (unsigned long)self.frameCount, self);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"Skipping requested frame %lu beyond bounds (total frame count: %lu) for animated image: %@", (unsigned long)index, (unsigned long)self.frameCount, self] withLevel:FLLogLevelWarn];
         return nil;
     }
     
@@ -398,7 +398,7 @@ static NSHashTable *allAnimatedImagesWeak;
     NSRange firstRange = NSMakeRange(self.requestedFrameIndex, self.frameCount - self.requestedFrameIndex);
     NSRange secondRange = NSMakeRange(0, self.requestedFrameIndex);
     if (firstRange.length + secondRange.length != self.frameCount) {
-        FLLogWarn(@"Two-part frame cache range doesn't equal full range.");
+        [FLAnimatedImage logString:@"Two-part frame cache range doesn't equal full range." withLevel:FLLogLevelWarn];
     }
     
     // Add to the requested list before we actually kick them off, so they don't get into the queue twice.
@@ -429,7 +429,7 @@ static NSHashTable *allAnimatedImagesWeak;
                     slowdownDuration = predrawDuration * predrawingSlowdownFactor - predrawDuration;
                     [NSThread sleepForTimeInterval:slowdownDuration];
                 }
-                FLLogVerbose(@"Predrew frame %lu in %f ms for animated image: %@", (unsigned long)i, (predrawDuration + slowdownDuration) * 1000, self);
+                [FLAnimatedImage logString:[NSString stringWithFormat:@"Predrew frame %lu in %f ms for animated image: %@", (unsigned long)i, (predrawDuration + slowdownDuration) * 1000, self] withLevel:FLLogLevelVerbose];
 #endif
                 // The results get returned one by one as soon as they're ready (and not in batch).
                 // The benefits of having the first frames as quick as possible outweigh building up a buffer to cope with potential hiccups when the CPU suddenly gets busy.
@@ -471,7 +471,7 @@ static NSHashTable *allAnimatedImagesWeak;
         imageSize = animatedImage.size;
     } else {
         // Bear trap to capture bad images; we have seen crashers cropping up on iOS 7.
-        FLLogError(@"`image` isn't of expected types `UIImage` or `FLAnimatedImage`: %@", image);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"`image` isn't of expected types `UIImage` or `FLAnimatedImage`: %@", image] withLevel:FLLogLevelError];
     }
     
     return imageSize;
@@ -518,7 +518,7 @@ static NSHashTable *allAnimatedImagesWeak;
         }
         // Double check our math, before we add the poster image index which may increase it by one.
         if ([indexesToCacheMutable count] != self.frameCacheSizeCurrent) {
-            FLLogWarn(@"Number of frames to cache doesn't equal expected cache size.");
+            [FLAnimatedImage logString:@"Number of frames to cache doesn't equal expected cache size." withLevel:FLLogLevelWarn];
         }
         
         [indexesToCacheMutable addIndex:self.posterImageFrameIndex];
@@ -560,7 +560,7 @@ static NSHashTable *allAnimatedImagesWeak;
 - (void)growFrameCacheSizeAfterMemoryWarning:(NSNumber *)frameCacheSize
 {
     self.frameCacheSizeMaxInternal = [frameCacheSize unsignedIntegerValue];
-    FLLogDebug(@"Grew frame cache size max to %lu after memory warning for animated image: %@", (unsigned long)self.frameCacheSizeMaxInternal, self);
+    [FLAnimatedImage logString:[NSString stringWithFormat:@"Grew frame cache size max to %lu after memory warning for animated image: %@", (unsigned long)self.frameCacheSizeMaxInternal, self] withLevel:FLLogLevelDebug];
     
     // Schedule resetting the frame cache size max completely after a while.
     const NSTimeInterval kResetDelay = 3.0;
@@ -571,7 +571,7 @@ static NSHashTable *allAnimatedImagesWeak;
 - (void)resetFrameCacheSizeMaxInternal
 {
     self.frameCacheSizeMaxInternal = FLAnimatedImageFrameCacheSizeNoLimit;
-    FLLogDebug(@"Reset frame cache size max (current frame cache size: %lu) for animated image: %@", (unsigned long)self.frameCacheSizeCurrent, self);
+    [FLAnimatedImage logString:[NSString stringWithFormat:@"Reset frame cache size max (current frame cache size: %lu) for animated image: %@", (unsigned long)self.frameCacheSizeCurrent, self] withLevel:FLLogLevelDebug];
 }
 
 
@@ -586,7 +586,7 @@ static NSHashTable *allAnimatedImagesWeak;
     [NSObject cancelPreviousPerformRequestsWithTarget:self.weakProxy selector:@selector(resetFrameCacheSizeMaxInternal) object:nil];
     
     // Go down to the minimum and by that implicitly immediately purge from the cache if needed to not get jettisoned by the system and start producing frames on-demand.
-    FLLogDebug(@"Attempt setting frame cache size max to %lu (previous was %lu) after memory warning #%lu for animated image: %@", (unsigned long)FLAnimatedImageFrameCacheSizeLowMemory, (unsigned long)self.frameCacheSizeMaxInternal, (unsigned long)self.memoryWarningCount, self);
+    [FLAnimatedImage logString:[NSString stringWithFormat:@"Attempt setting frame cache size max to %lu (previous was %lu) after memory warning #%lu for animated image: %@", (unsigned long)FLAnimatedImageFrameCacheSizeLowMemory, (unsigned long)self.frameCacheSizeMaxInternal, (unsigned long)self.memoryWarningCount, self] withLevel:FLLogLevelDebug];
     self.frameCacheSizeMaxInternal = FLAnimatedImageFrameCacheSizeLowMemory;
     
     // Schedule growing larger again after a while, but cap our attempts to prevent a periodic sawtooth wave (ramps upward and then sharply drops) of memory usage.
@@ -623,7 +623,7 @@ static NSHashTable *allAnimatedImagesWeak;
     CGColorSpaceRef colorSpaceDeviceRGBRef = CGColorSpaceCreateDeviceRGB();
     // Early return on failure!
     if (!colorSpaceDeviceRGBRef) {
-        FLLogError(@"Failed to `CGColorSpaceCreateDeviceRGB` for image %@", imageToPredraw);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"Failed to `CGColorSpaceCreateDeviceRGB` for image %@", imageToPredraw] withLevel:FLLogLevelError];
         return imageToPredraw;
     }
     
@@ -663,7 +663,7 @@ static NSHashTable *allAnimatedImagesWeak;
     CGColorSpaceRelease(colorSpaceDeviceRGBRef);
     // Early return on failure!
     if (!bitmapContextRef) {
-        FLLogError(@"Failed to `CGBitmapContextCreate` with color space %@ and parameters (width: %zu height: %zu bitsPerComponent: %zu bytesPerRow: %zu) for image %@", colorSpaceDeviceRGBRef, width, height, bitsPerComponent, bytesPerRow, imageToPredraw);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"Failed to `CGBitmapContextCreate` with color space %@ and parameters (width: %zu height: %zu bitsPerComponent: %zu bytesPerRow: %zu) for image %@", colorSpaceDeviceRGBRef, width, height, bitsPerComponent, bytesPerRow, imageToPredraw] withLevel:FLLogLevelError];
         return imageToPredraw;
     }
     
@@ -676,7 +676,7 @@ static NSHashTable *allAnimatedImagesWeak;
     
     // Early return on failure!
     if (!predrawnImage) {
-        FLLogError(@"Failed to `imageWithCGImage:scale:orientation:` with image ref %@ created with color space %@ and bitmap context %@ and properties and properties (scale: %f orientation: %ld) for image %@", predrawnImageRef, colorSpaceDeviceRGBRef, bitmapContextRef, imageToPredraw.scale, (long)imageToPredraw.imageOrientation, imageToPredraw);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"Failed to `imageWithCGImage:scale:orientation:` with image ref %@ created with color space %@ and bitmap context %@ and properties and properties (scale: %f orientation: %ld) for image %@", predrawnImageRef, colorSpaceDeviceRGBRef, bitmapContextRef, imageToPredraw.scale, (long)imageToPredraw.imageOrientation, imageToPredraw] withLevel:FLLogLevelError];
         return imageToPredraw;
     }
     
@@ -696,6 +696,26 @@ static NSHashTable *allAnimatedImagesWeak;
     return description;
 }
 
+
+@end
+
+#pragma mark - Logging
+
+@implementation FLAnimatedImage (Logging)
+
+static void (^_logBlock)(NSString *logString, FLLogLevel logLevel) = nil;
+
++ (void)setLogBlock:(void (^)(NSString *logString, FLLogLevel logLevel))logBlock
+{
+    _logBlock = logBlock;
+}
+
++ (void)logString:(NSString *)logString withLevel:(FLLogLevel)level
+{
+    if (_logBlock) {
+        _logBlock(logString, level);
+    }
+}
 
 @end
 

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -236,7 +236,7 @@
     // If for some reason a wild call makes it through when we shouldn't be animating, bail.
     // Early return!
     if (!self.shouldAnimate) {
-        FLLogWarn(@"Trying to animate image when we shouldn't: %@", self);
+        [FLAnimatedImage logString:[NSString stringWithFormat:@"Trying to animate image when we shouldn't: %@", self] withLevel:FLLogLevelWarn];
         return;
     }
     
@@ -247,7 +247,7 @@
         // If we have a nil image (e.g. waiting for frame), don't update the view nor playhead.
         UIImage *image = [self.animatedImage imageLazilyCachedAtIndex:self.currentFrameIndex];
         if (image) {
-            FLLogVerbose(@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Showing frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage] withLevel:FLLogLevelVerbose];
             self.currentFrame = image;
             if (self.needsDisplayWhenImageBecomesAvailable) {
                 [self.layer setNeedsDisplay];
@@ -278,7 +278,7 @@
                 self.needsDisplayWhenImageBecomesAvailable = YES;
             }
         } else {
-            FLLogDebug(@"Waiting for frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage);
+            [FLAnimatedImage logString:[NSString stringWithFormat:@"Waiting for frame %lu for animated image: %@", (unsigned long)self.currentFrameIndex, self.animatedImage] withLevel:FLLogLevelDebug];
 #if defined(DEBUG) && DEBUG
             if ([self.debug_delegate respondsToSelector:@selector(debug_animatedImageView:waitingForFrame:duration:)]) {
                 [self.debug_delegate debug_animatedImageView:self waitingForFrame:self.currentFrameIndex duration:(NSTimeInterval)self.displayLink.duration];

--- a/README.md
+++ b/README.md
@@ -52,7 +52,22 @@ It's flexible to integrate in your custom image loading stack and backwards comp
 
 It uses ARC and the Apple frameworks `QuartzCore`, `ImageIO`, `MobileCoreServices`, and `CoreGraphics`.
 
-It has fine-grained logging. By default, it uses NSLog. However, if your project uses [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack), it automatically can detect that and use CocoaLumberjack to send logs to the configured output.
+It is capable of fine-grained logging. A block can be set on `FLAnimatedImage` that's invoked when logging occurs with various log levels via the `+setLogBlock:` method. For example:
+
+```objective-c
+// Set up FLAnimatedImage logging.
+[FLAnimatedImage setLogBlock:^(NSString *logString, FLLogLevel logLevel) {
+    // Using NSLog
+    NSLog(@"%@", logString);
+    
+    // ...or CocoaLumberjackLogger only logging warnings and errors
+    if (logLevel == FLLogLevelError) {
+        DDLogError(@"%@", logString);
+    } else if (logLevel == FLLogLevelWarn) {
+        DDLogWarn(@"%@", logString);
+    }
+}];
+```
 
 Since FLAnimatedImage is licensed under MIT, it's compatible with the terms of using it for any app on the App Store.
 


### PR DESCRIPTION
This decouples `FLAnimatedImage` from any specific logging libraries, logging is instead handled by passing a block that's invoked when logging should occur to `FLAnimatedImage` via `+setLogBlock:`. This resolves issue https://github.com/Flipboard/FLAnimatedImage/issues/107 which was preventing FLAnimatedImage from working in projects that also used Cocoa Lumberjack Logger when built with Carthage.