### PR TITLE
Hide debugging functionality from public headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/*
 xcuserdata
 profile
 *.moved-aside
+*.xcworkspacedata
 
 # CocoaPods
 #

--- a/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImage/FLAnimatedImage.h
@@ -61,7 +61,6 @@
 #if defined(DEBUG) && DEBUG
 // Only intended to report internal state for debugging
 @property (nonatomic, weak) id<FLAnimatedImageDebugDelegate> debug_delegate;
-@property (nonatomic, strong) NSMutableDictionary *debug_info; // To track arbitrary data (e.g. original URL, loading durations, cache hits, etc.)
 #endif
 
 @end

--- a/FLAnimatedImage/FLAnimatedImage.h
+++ b/FLAnimatedImage/FLAnimatedImage.h
@@ -12,10 +12,6 @@
 // Allow user classes conveniently just importing one header.
 #import "FLAnimatedImageView.h"
 
-#if defined(DEBUG) && DEBUG
-@protocol FLAnimatedImageDebugDelegate;
-#endif
-
 
 #ifndef NS_DESIGNATED_INITIALIZER
     #if __has_attribute(objc_designated_initializer)
@@ -58,11 +54,6 @@
 
 @property (nonatomic, strong, readonly) NSData *data; // The data the receiver was initialized with; read-only
 
-#if defined(DEBUG) && DEBUG
-// Only intended to report internal state for debugging
-@property (nonatomic, weak) id<FLAnimatedImageDebugDelegate> debug_delegate;
-#endif
-
 @end
 
 typedef NS_ENUM(NSUInteger, FLLogLevel) {
@@ -86,16 +77,3 @@ typedef NS_ENUM(NSUInteger, FLLogLevel) {
 + (instancetype)weakProxyForObject:(id)targetObject;
 
 @end
-
-
-#if defined(DEBUG) && DEBUG
-@protocol FLAnimatedImageDebugDelegate <NSObject>
-
-@optional
-
-- (void)debug_animatedImage:(FLAnimatedImage *)animatedImage didUpdateCachedFrames:(NSIndexSet *)indexesOfFramesInCache;
-- (void)debug_animatedImage:(FLAnimatedImage *)animatedImage didRequestCachedFrame:(NSUInteger)index;
-- (CGFloat)debug_animatedImagePredrawingSlowdownFactor:(FLAnimatedImage *)animatedImage;
-
-@end
-#endif

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -37,6 +37,16 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 };
 
 
+#if defined(DEBUG) && DEBUG
+@protocol FLAnimatedImageDebugDelegate <NSObject>
+@optional
+- (void)debug_animatedImage:(FLAnimatedImage *)animatedImage didUpdateCachedFrames:(NSIndexSet *)indexesOfFramesInCache;
+- (void)debug_animatedImage:(FLAnimatedImage *)animatedImage didRequestCachedFrame:(NSUInteger)index;
+- (CGFloat)debug_animatedImagePredrawingSlowdownFactor:(FLAnimatedImage *)animatedImage;
+@end
+#endif
+
+
 @interface FLAnimatedImage ()
 
 @property (nonatomic, assign, readonly) NSUInteger frameCacheSizeOptimal; // The optimal number of frames to cache based on image size & number of frames; never changes
@@ -55,6 +65,10 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
 // We are lying about the actual type here to gain static type checking and eliminate casts.
 // The actual type of the object is `FLWeakProxy`.
 @property (nonatomic, strong, readonly) FLAnimatedImage *weakProxy;
+
+#if defined(DEBUG) && DEBUG
+@property (nonatomic, weak) id<FLAnimatedImageDebugDelegate> debug_delegate;
+#endif
 
 @end
 

--- a/FLAnimatedImage/FLAnimatedImageView.h
+++ b/FLAnimatedImage/FLAnimatedImageView.h
@@ -29,20 +29,4 @@
 @property (nonatomic, strong, readonly) UIImage *currentFrame;
 @property (nonatomic, assign, readonly) NSUInteger currentFrameIndex;
 
-#if defined(DEBUG) && DEBUG
-// Only intended to report internal state for debugging
-@property (nonatomic, weak) id<FLAnimatedImageViewDebugDelegate> debug_delegate;
-#endif
-
 @end
-
-
-#if defined(DEBUG) && DEBUG
-@protocol FLAnimatedImageViewDebugDelegate <NSObject>
-
-@optional
-
-- (void)debug_animatedImageView:(FLAnimatedImageView *)animatedImageView waitingForFrame:(NSUInteger)index duration:(NSTimeInterval)duration;
-
-@end
-#endif

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -12,6 +12,14 @@
 #import <QuartzCore/QuartzCore.h>
 
 
+#if defined(DEBUG) && DEBUG
+@protocol FLAnimatedImageViewDebugDelegate <NSObject>
+@optional
+- (void)debug_animatedImageView:(FLAnimatedImageView *)animatedImageView waitingForFrame:(NSUInteger)index duration:(NSTimeInterval)duration;
+@end
+#endif
+
+
 @interface FLAnimatedImageView ()
 
 // Override of public `readonly` properties as private `readwrite`
@@ -24,6 +32,10 @@
 
 @property (nonatomic, assign) BOOL shouldAnimate; // Before checking this value, call `-updateShouldAnimate` whenever the animated image or visibility (window, superview, hidden, alpha) has changed.
 @property (nonatomic, assign) BOOL needsDisplayWhenImageBecomesAvailable;
+
+#if defined(DEBUG) && DEBUG
+@property (nonatomic, weak) id<FLAnimatedImageViewDebugDelegate> debug_delegate;
+#endif
 
 @end
 

--- a/FLAnimatedImageDemo/DebugView.h
+++ b/FLAnimatedImageDemo/DebugView.h
@@ -16,11 +16,8 @@ typedef NS_ENUM(NSUInteger, DebugViewStyle) {
 };
 
 
+// Conforms to private FLAnimatedImageDebugDelegate and FLAnimatedImageViewDebugDelegate protocols, used in sample project.
 @interface DebugView : UIView
-#if defined(DEBUG) && DEBUG
-<FLAnimatedImageDebugDelegate,
-FLAnimatedImageViewDebugDelegate>
-#endif
 
 @property (nonatomic, weak) FLAnimatedImage *image;
 @property (nonatomic, weak) FLAnimatedImageView *imageView;

--- a/FLAnimatedImageDemo/RootViewController.m
+++ b/FLAnimatedImageDemo/RootViewController.m
@@ -29,6 +29,27 @@
 
 @end
 
+// Internal properties on FLAnimatedImage and FLAnimatedImageView, only availabe in debug and used exclusively for the sample project.
+#if defined(DEBUG) && DEBUG
+
+@interface FLAnimatedImage (Private)
+@property (nonatomic, weak) id debug_delegate;
+@end
+
+@implementation FLAnimatedImage (Private)
+@dynamic debug_delegate;
+@end
+
+@interface FLAnimatedImageView (Private)
+@property (nonatomic, weak) id debug_delegate;
+@end
+
+@implementation FLAnimatedImageView (Private)
+@dynamic debug_delegate;
+@end
+
+#endif
+
 
 @implementation RootViewController
 


### PR DESCRIPTION
FLAnimatedImage and FLAnimatedImageView have exposed internal debugging delegate properties and protocols. In practice, these are only used in the sample project and aren't intended for public use. Furthermore, the public header had the under `#if defined(DEBUG) && DEBUG`, which is problematic if FLAnimateImage is built as a framework but then included in a project being built as debug.

This PR omits debugging functionality from FLAnimatedImage's public headers.