### PR TITLE
Crash fix

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -49,9 +49,23 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.runLoopMode = [[self class] defaultRunLoopMode];
+        [self commonInit];
     }
     return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    self.runLoopMode = [[self class] defaultRunLoopMode];
 }
 
 


### PR DESCRIPTION
When used in IB, the runLoopMode property isn't assigned causing an exception.
This is a regression, introduced in my previous PR. Sorry!