### PR TITLE
Fix crash in FLAnimatedImage -imageAtIndex:

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -514,6 +514,12 @@ static NSHashTable *allAnimatedImagesWeak;
 {
     // It's very important to use the cached `_imageSource` since the random access to a frame with `CGImageSourceCreateImageAtIndex` turns from an O(1) into an O(n) operation when re-initializing the image source every time.
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(_imageSource, index, NULL);
+
+    // Early return for nil
+    if (!imageRef) {
+        return nil;
+    }
+
     UIImage *image = [UIImage imageWithCGImage:imageRef];
     CFRelease(imageRef);
     


### PR DESCRIPTION
The issue can be reproduced in the iOS 9.2 iPad simulator and on an 9.2.1 iPhone 6+.

Reproduction Steps
---

1. Change FLAnimatedImageDemo to load gif from this url: [https://i.imgur.com/7Hpfb0o.gif](https://i.imgur.com/7Hpfb0o.gif).

        NSURL *url2 = [NSURL URLWithString:@"https://cloud.githubusercontent.com/assets/1567433/10417835/1c97e436-7052-11e5-8fb5-69373072a5a0.gif"];
    to

        NSURL *url2 = [NSURL URLWithString:@"https://i.imgur.com/7Hpfb0o.gif"];

2. Run FLAnimatedImageDemo

Result
---
`FLAnimatedImage` crashes in the `-imageAtIndex:` function:

![](https://i.imgur.com/Sp3b8PW.png)

This is a result of calling `CFRelease(imageRef)` with a `nil` `imageRef`.

Fix
---

Add an early return in  `-imageAtIndex:` for a `nil` result from `CGImageSourceCreateImageAtIndex`. A `nil` return value is consumed cleanly from `-imageAtIndex:`'s calling code in `-addFrameIndexesToCache:`.