### PR TITLE
Fix default run loop mode crash

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -293,6 +293,13 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
     }
 }
 
+- (NSString *)runLoopMode {
+    if (_runLoopMode) {
+        return _runLoopMode;
+    }
+    return NSDefaultRunLoopMode;
+}
+
 - (void)stopAnimating
 {
     if (self.animatedImage) {

--- a/FLAnimatedImageDemo.xcodeproj/project.pbxproj
+++ b/FLAnimatedImageDemo.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		87CB5A131935A8C600620C16 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 87CB5A0C1935A8C600620C16 /* main.m */; };
 		87CB5A141935A8C600620C16 /* PlayheadView.m in Sources */ = {isa = PBXBuildFile; fileRef = 87CB5A0E1935A8C600620C16 /* PlayheadView.m */; };
 		87CB5A151935A8C600620C16 /* RSPlayPauseButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 87CB5A101935A8C600620C16 /* RSPlayPauseButton.m */; };
-		B7D828351C7524DC004D60DA /* FLAnimatedImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7D828341C7524DC004D60DA /* FLAnimatedImage.framework */; };
-		B7D828361C7524DC004D60DA /* FLAnimatedImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B7D828341C7524DC004D60DA /* FLAnimatedImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -36,7 +34,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B7D828361C7524DC004D60DA /* FLAnimatedImage.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -73,7 +70,6 @@
 		87CB5A0F1935A8C600620C16 /* RSPlayPauseButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RSPlayPauseButton.h; path = FLAnimatedImageDemo/RSPlayPauseButton.h; sourceTree = "<group>"; };
 		87CB5A101935A8C600620C16 /* RSPlayPauseButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RSPlayPauseButton.m; path = FLAnimatedImageDemo/RSPlayPauseButton.m; sourceTree = "<group>"; };
 		87CB5A171935A93F00620C16 /* FLAnimatedImageDemo-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FLAnimatedImageDemo-Prefix.pch"; path = "FLAnimatedImageDemo/FLAnimatedImageDemo-Prefix.pch"; sourceTree = "<group>"; };
-		B7D828341C7524DC004D60DA /* FLAnimatedImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = FLAnimatedImage.framework; path = "/Users/zenglekidd/Library/Developer/Xcode/DerivedData/FLAnimatedImage-bekujibksyilrubmjsirveabffrz/Build/Products/Debug-iphoneos/FLAnimatedImage.framework"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,7 +82,6 @@
 				872EBE74178B825500B7531B /* CoreGraphics.framework in Frameworks */,
 				872EBE70178B825500B7531B /* UIKit.framework in Frameworks */,
 				872EBEBD178B8FA000B7531B /* QuartzCore.framework in Frameworks */,
-				B7D828351C7524DC004D60DA /* FLAnimatedImage.framework in Frameworks */,
 				872EBEB3178B89DF00B7531B /* ImageIO.framework in Frameworks */,
 				872EBEBB178B8F9000B7531B /* MobileCoreServices.framework in Frameworks */,
 			);
@@ -98,7 +93,6 @@
 		872EBE63178B825500B7531B = {
 			isa = PBXGroup;
 			children = (
-				B7D828341C7524DC004D60DA /* FLAnimatedImage.framework */,
 				872EBE75178B825500B7531B /* FLAnimatedImageDemo */,
 				872EBE6E178B825500B7531B /* Frameworks */,
 				872EBE6D178B825500B7531B /* Products */,


### PR DESCRIPTION
We're using FLAnimatedImage together with `NYTPhotoViewer` and are experiencing a crash since FLAnimatedImage v1.0.11.

![screen shot 2016-02-19 at 9 17 08 am](https://cloud.githubusercontent.com/assets/126418/13160274/8494fd72-d6ea-11e5-91d1-f6a09c3f8d4e.png)

This results in breaking changes introduced in the custom runloop feature added in the most recent update. FLAnimatedImage can be successfully instantiated without having the `self.defaultRunLoopMode` being set. I've added a getter to return the `NSDefaultRunLoopMode` if this is the case.

This crash appeared just recently because NYTPhotoViewer requires `FLAnimatedImage ~> 1.0.8` so it's updated to 1.0.11 without changing its implementation of FLAnimatedImage. (Which shouldn't be necessary anyway as this FLAnimatedIMage update is just a bugfix release.)