### PR TITLE
default loop count should be 1

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -228,7 +228,12 @@ static NSHashTable *allAnimatedImagesWeak;
         //     };
         // }
         NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, NULL);
-        _loopCount = [[[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
+        id loopCountObj = [[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount];
+        if ([loopCountObj respondsToSelector:@selector(unsignedIntegerValue)]) {
+            _loopCount = [loopCountObj unsignedIntegerValue];
+        } else {
+            _loopCount = 1;
+        }
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);


### PR DESCRIPTION
When Netscape Extension is not available in GIF, most web browsers play it only once.
But currently FLAnimatedImage plays it forever.
To fix this, need to check key `LoopCount` exists in the dictionary. When it doesn't exist, default value should be 1.

Can verify with this image: http://ww3.sinaimg.cn/mw1024/685b99a9gw1f0dbnnt07eg2053051mx5.gif

Following issue is related to this PR:
https://github.com/Flipboard/FLAnimatedImage/issues/156