### PR TITLE
Changing logic to select frameCacheSizeOptimal.

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -324,7 +324,8 @@ static NSHashTable *allAnimatedImagesWeak;
             CGFloat animatedImageDataSize = animatedImageDataSizePerFrame * (self.frameCount - skippedFrameCount);
             if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryAll) {
                 _frameCacheSizeOptimal = self.frameCount;
-            } else if (animatedImageDataSizePerFrame * FLAnimatedImageFrameCacheSizeDefault <= FLAnimatedImageDataSizeCategoryAll) {
+            } else if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryDefault ||
+                       animatedImageDataSizePerFrame * FLAnimatedImageFrameCacheSizeDefault <= FLAnimatedImageDataSizeCategoryAll) {
                 // This value doesn't depend on device memory much because if we're not keeping all frames in memory we will always be decoding 1 frame up ahead per 1 frame that gets played and at this point we might as well just keep a small buffer just large enough to keep from running out of frames.
                 _frameCacheSizeOptimal = FLAnimatedImageFrameCacheSizeDefault;
             } else {

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -320,10 +320,11 @@ static NSHashTable *allAnimatedImagesWeak;
         if (optimalFrameCacheSize == 0) {
             // Calculate the optimal frame cache size: try choosing a larger buffer window depending on the predicted image size.
             // It's only dependent on the image size & number of frames and never changes.
-            CGFloat animatedImageDataSize = CGImageGetBytesPerRow(self.posterImage.CGImage) * self.size.height * (self.frameCount - skippedFrameCount) / MEGABYTE;
+            CGFloat animatedImageDataSizePerFrame = CGImageGetBytesPerRow(self.posterImage.CGImage) * self.size.height / MEGABYTE;
+            CGFloat animatedImageDataSize = animatedImageDataSizePerFrame * (self.frameCount - skippedFrameCount);
             if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryAll) {
                 _frameCacheSizeOptimal = self.frameCount;
-            } else if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryDefault) {
+            } else if (animatedImageDataSizePerFrame * FLAnimatedImageFrameCacheSizeDefault <= FLAnimatedImageDataSizeCategoryAll) {
                 // This value doesn't depend on device memory much because if we're not keeping all frames in memory we will always be decoding 1 frame up ahead per 1 frame that gets played and at this point we might as well just keep a small buffer just large enough to keep from running out of frames.
                 _frameCacheSizeOptimal = FLAnimatedImageFrameCacheSizeDefault;
             } else {


### PR DESCRIPTION
Fixed an issue causing delays when playing certain GIF files due to selecting `FLAnimatedImageFrameCacheSizeLowMemory` even though `FLAnimatedImageFrameCacheSizeDefault` can be selected.

## Problem
Our app downloads and plays gif files from the server, some of them are very slow to play.
When I tried to figure out the cause, `_frameCacheSizeOptimal` was selected as `FLAnimatedImageFrameCacheSizeLowMemory` when loading `FLAnimatedImage` `animatedImageWithGIFData` from the file.
So it could not read directly from the cache and there was a delay in playback.

This GIF file is 419KB in size, 720 * 200 pixels, and has 300 frames.

CGFloat animatedImageDataSize = CGImageGetBytesPerRow(self.posterImage.CGImage) * self.size.height * (self.frameCount - skippedFrameCount) / MEGABYTE;
=>
animatedImageDataSize = (2880 * 200) * 300 / (1024 * 1024) = **164.795**

`_frameCacheSizeOptimal` is set to `FLAnimatedImageFrameCacheSizeLowMemory` because `animatedImageDataSize` is larger than `FLAnimatedImageDataSizeCategoryDefault` (**75**).

When the `_frameCacheSizeOptimal` is set to `FLAnimatedImageFrameCacheSizeLowMemory`, the reason for the delay is that when `imageLazilyCachedAtIndex` is performed in `displayDidRefresh`, `nil` is returned because there is no image in the cache, and the `accumulator` does not increase in `duration`.

This GIF file has a lot of frames but it does not have a large size per frame, so I think it's a problem to choose not to cache at all.

## Fix
This GIF file is small size per frame, so it seems more appropriate to select `FLAnimatedImageFrameCacheSizeDefault` rather than `FLAnimatedImageFrameCacheSizeLowMemory`, and the modified logic can be seen in commit.

Check the following youtube link for the video comparing the before/after changes.
[before and after video](https://youtu.be/R0CRRz0qixo)

As a workaround, I can specify an `optimalFrameCacheSize` of `FLAnimatedImageFrameCacheSizeDefault` (**5**), but I need to use `animatedImageWithGIFData` to automatically select the `frameCacheSizeOptimal` because I need to input various GIF files.

The following are GIF files with delayed playback problems. (All files with large frameCounts cause problems.)
http://netdna.webdesignerdepot.com/uploads/2013/07/dribble_gif.gif
http://netdna.webdesignerdepot.com/uploads7/50-inspiring-animated-gifs/006.gif
http://netdna.webdesignerdepot.com/uploads/2013/07/2222.gif


