### PR TITLE
Always set an image in UIImageOrientationUp before setting up animated image

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -97,8 +97,13 @@
 {
     if (![_animatedImage isEqual:animatedImage]) {
         if (animatedImage) {
-            // Clear out the image.
-            super.image = nil;
+            if (super.image) {
+                // We need to apply an arbitrary UIImageOrientationUp image to ensure this view's internal state is correct.
+                // Otherwise some animated image will be rendered in wrong orientation, see https://github.com/Flipboard/FLAnimatedImage/issues/100
+                super.image = [UIImage imageWithCGImage:super.image.CGImage scale:1.0 orientation:UIImageOrientationUp];
+                // Clear out the image.
+                super.image = nil;
+            }
             // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
             super.highlighted = NO;
             // UIImageView seems to bypass some accessors when calculating its intrinsic content size, so this ensures its intrinsic content size comes from the animated image.


### PR DESCRIPTION
Fixed #100,

I tried to apply a single pixel image in `UIImageOrientationUp` before we reset `image` property to `nil` on this view. And Voilà! It works!

So the easiest fix is to set the an arbitrary image in `UIImageOrientationUp`, I choose to reuse the existing `super.image` to avoid creating a new one.