### PR TITLE
If a GIF image has no Netscape 2.0 loop extension, it is meant to play once and then stop.

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -229,7 +229,11 @@ static NSHashTable *allAnimatedImagesWeak;
         // }
         NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, NULL);
         id loopCount = [[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount];
-        _loopCount = loopCount?[loopCount unsignedIntegerValue]:1;
+        if (loopCount && [loopCount unsignedIntegerValue] == 0) {
+            _loopCount = 0;
+        } else {
+            _loopCount = [loopCount unsignedIntegerValue] + 1;
+        }
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -228,7 +228,8 @@ static NSHashTable *allAnimatedImagesWeak;
         //     };
         // }
         NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, NULL);
-        _loopCount = [[[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
+        id loopCount = [[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount];
+        _loopCount = loopCount?[loopCount unsignedIntegerValue]:1;
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);


### PR DESCRIPTION
If a GIF image has no Netscape 2.0 loop extension, it is meant to play once and then stop.