### PR TITLE
fix incorrect frame interval after iOS 11.4

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -296,7 +296,12 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
         // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display (~60Hz).
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
         const NSTimeInterval kDisplayRefreshRate = 60.0; // 60Hz
-        self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+         NSInteger frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+        if (@available(iOS 10.0, *)) {
+            self.displayLink.preferredFramesPerSecond = frameInterval;
+        } else {
+            self.displayLink.frameInterval = frameInterval;
+        }
 
         self.displayLink.paused = NO;
     } else {


### PR DESCRIPTION
fiexed gif display bug of http://imcut.jollychic.com/uploads/jollyimg/imageMaterialLib/201807/23/IL201807231401385763.gif, actually frameinterval is 37 but always set to 60