### PR TITLE
fixed incorrect frame interval after iOS 10.4 for some frame interval…

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -301,7 +301,13 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
         // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display (~60Hz).
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
         const NSTimeInterval kDisplayRefreshRate = 60.0; // 60Hz
-        self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+         NSInteger frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+        if (@available(iOS 10, *)) {//after iOS 10(.x) frameInterval should be divided with no remainder, or using preferredFramesPerSecond(but still has some problem.)
+            NSInteger fixedInterval = gcd(kDisplayRefreshRate, frameInterval);
+            self.displayLink.frameInterval = fixedInterval;
+        } else {
+            self.displayLink.frameInterval = frameInterval;
+        }
 
         self.displayLink.paused = NO;
     } else {


### PR DESCRIPTION
…
![il201807231401385763](https://user-images.githubusercontent.com/9944367/43137321-244b27a8-8f7e-11e8-96a1-8241f6ade7c8.gif)
![il201803161542568016](https://user-images.githubusercontent.com/9944367/43137339-2fbd3504-8f7e-11e8-99d9-c48c9f85d230.gif)

 value such as  18/22/34/37