### PR TITLE
Fix the bug when FLAnimatedImageView firstly show one EXIF rotation JPEG `UIImage`, later animated GIF `FLAnimatedImage` will also be rotated

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -101,6 +101,9 @@
 {
     if (![_animatedImage isEqual:animatedImage]) {
         if (animatedImage) {
+            // UIImageView's `setImage:`, will internally call layer's `setContentsTransoforms:` based on the image.imageOrientation. The `contentsTransoforms` will effect layer rendering rotation because the CGImage's bitmap buffer does not actually take rotation.
+            // However, when call `setImage:nil`, this `contentsTransoforms` will not be reset to identity. Further animation frame will rendered as rotated. So we must firstlly call it with the poster image to clear the previous state
+            super.image = animatedImage.posterImage;
             // Clear out the image.
             super.image = nil;
             // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).


### PR DESCRIPTION
# Related Issue
The related issue in FLAnimatedImage repo, it's https://github.com/Flipboard/FLAnimatedImage/issues/181

The related issue in SDWebImage repo, it's https://github.com/rs/SDWebImage/issues/2402
https://github.com/rs/SDWebImage/issues/1317

# Reproduce Demo
https://github.com/ericeddy/FLAnimatedImage-RotationIssue

### What cause this problem 

`FLAnimatedImageView`, it's a UIImageView subclass, which manually specify [CALayer.contents](https://developer.apple.com/documentation/quartzcore/calayer/1410773-contents) with the current rendering frame's `CGImage`. And they use a [CADisplayLink](https://www.google.com/search?q=CADisplayLink&oq=CADisplayLink&aqs=chrome..69i57.213j0j7&sourceid=chrome&ie=UTF-8) as a timer, to refresh current frame, finally produce the visual animation.

However, `CALayer` itself, contains a private property, called `contentsTransform`. You can check the private header of [CALayer](http://developer.limneos.net/index.php?ios=11.1.2&framework=QuartzCore.framework&header=CALayer.h). `CALayer` will calculate current `UIImage.imageOrientation` and translate to `CGAffineTransform` to render the bitmap. Why they to do this it's because it does not actually take rotation on `CGImage`'s bitmap when you create UIImage with [-[UIImage imageWithCGImage:scale:orientation:]](https://www.google.com/search?q=UIImage+imageWithCGImage&oq=UIImage+imageWithCGImage&aqs=chrome..69i57.2422j0j7&sourceid=chrome&ie=UTF-8), The both `scale` and `imageOrientation` are just hint to the CALayer's property `contentsScale` and `contentsTransform`. So that `CALayer` use the `contentsTransform` to actually do rotation about the bitmap.

Which means, actually, `CALayer` draw its contents, based on the both public `CALayer.transform` and private `CALayer.contentsTransform` two properties.

See the screenshot during View Debug and print out the CALayer information. The actually `CALayer.contents` bitmap show the correct orientation, but the rendering result cause a rotation because the CALayer contains a `contentsTransform = CGAffineTransform (0 1.06667; -0.9375 0; 375 0)`, which is a right-90 degress rotation.


<img width="1440" alt="2018-07-27 9 31 10" src="https://user-images.githubusercontent.com/6919743/43323532-8096eff2-91e4-11e8-85be-55ced6521031.png">


After I use KVO to observe this `contentsTransform` changes, I found that the only write on this property was happend on `-[UIImageView setImage:]` function call with a **non-nil** `UIImage`. The **non-nil** is really important, when you sepcify nil, the `contentsTransform` property leave there without reset to identity transform. (Because UIKit assume you don't touch layer.contents and so they don't need to reset the state)

<img width="1552" alt="2018-07-27 8 09 26" src="https://user-images.githubusercontent.com/6919743/43323566-986e304a-91e4-11e8-93da-42ab7bd147ad.png">


So now, you may know the reason now. Correct, the previous JPEG image which contains non-Up image orienation will change the `conrtentsTransform`, but the newly set `FLAnimatedImage` does not clear that transform, cause the final rotation. I check the current FLAnimatedImage code and finally find the bug. The root case is that `-[FLAnimatedImage setAnimatedImage:]` does not do the correct thing, to reset the super `UIImageView` state about image.

```objective-c
- (void)setAnimatedImage:(FLAnimatedImage *)animatedImage
{
    if (![_animatedImage isEqual:animatedImage]) {
        if (animatedImage) {
            // Clear out the image.
            super.image = nil;   // -> This will not reset `contentsTransform`, not actually "Clear out the image."
            // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
            super.highlighted = NO;
           //...
    }
}
```

### Solution

The naive solution, it's quite simple, firstlly call `super.image = non-nil image` and then call `super.image = nil`. Only one line code and the issue disappear.


```diff
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -101,6 +101,7 @@
 {
     if (![_animatedImage isEqual:animatedImage]) {
         if (animatedImage) {
+            // Reset `contentsTransform` state
+            super.image = animatedImage.posterImage;
             // Clear out the image.
             super.image = nil;
             // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).

``` 

From my personal opinion, I think they should always call `[super setImage:]` during `[FLAnimatedImageView setAnimatedImage:]`. If you don't call super, you may loss internal consistent behavior during subclass. But anyway, this fix is much simpler.