### PR TITLE
The LoopCount property default value

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -228,7 +228,8 @@ static NSHashTable *allAnimatedImagesWeak;
         //     };
         // }
         NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, NULL);
-        _loopCount = [[[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
+        NSNumber *loopContValue = [[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount];
+        _loopCount = loopContValue ? loopContValue.unsignedIntegerValue : 1;
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);


### PR DESCRIPTION
Usually, no LoopCount property means that the loop count is 1 rather than indefinite. For example, the Photoshop always create a gif without LoopCount info if the loop count was setted to 1.