### PR TITLE
animated image display only once will cause error

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -228,7 +228,14 @@ static NSHashTable *allAnimatedImagesWeak;
         //     };
         // }
         NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, NULL);
-        _loopCount = [[[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
+        
+        // an animated image display for once will return a nil LoopCount in its dictionary, which will be convert to 0
+        id loopCountObject = [[imageProperties objectForKey:(id)kCGImagePropertyGIFDictionary] objectForKey:(id)kCGImagePropertyGIFLoopCount];
+        if (loopCountObject) {
+            _loopCount = [loopCountObject unsignedIntegerValue];
+        } else {
+            _loopCount = 1;
+        }
         
         // Iterate through frame images
         size_t imageCount = CGImageSourceGetCount(_imageSource);


### PR DESCRIPTION
an animated image display for once will return a nil LoopCount in its dictionary, which will be convert to 0