### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/FLAnimatedImage.podspec
+++ b/FLAnimatedImage.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |spec|
   spec.platform         = :ios, "6.0"
   spec.source           = { :git => "https://github.com/Flipboard/FLAnimatedImage.git", :tag => "1.0.14" }
   spec.source_files     = "FLAnimatedImage/**/*.{h,m}"
-  spec.frameworks       = "QuartzCore", "ImageIO", "MobileCoreServices", "CoreGraphics"
+  spec.frameworks       = "QuartzCore", "ImageIO", "CoreGraphics"
   spec.requires_arc     = true
 end


### PR DESCRIPTION
Close #238

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
