### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "FLAnimatedImage",
             path: "FLAnimatedImage",
-            exclude: [ "FLAnimatedImage/Info.plist" ],
+            exclude: [ "FLAnimatedImage/FLAnimatedImage/Info.plist" ],
             publicHeadersPath: "FLAnimatedImage"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "FLAnimatedImage",
+    platforms: [
+        .iOS(.v8)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -18,7 +21,7 @@ let package = Package(
             name: "FLAnimatedImage",
             path: "FLAnimatedImage",
             exclude: [ "Info.plist" ],
-            sources: [ "./FLAnimatedImage" ],
+            sources: [ "FLAnimatedImageView.m", "FLAnimatedImage.m" ],
             publicHeadersPath: "./FLAnimatedImage"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .target(
             name: "FLAnimatedImage",
             path: "FLAnimatedImage",
-            exclude: [ "FLAnimatedImage/FLAnimatedImage/Info.plist" ],
+            sources: [ "FLAnimatedImage" ],
+            exclude: [ "FLAnimatedImage/Info.plist" ],
             publicHeadersPath: "FLAnimatedImage"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         .target(
             name: "FLAnimatedImage",
             path: "FLAnimatedImage",
-            sources: [ "FLAnimatedImage" ],
             exclude: [ "FLAnimatedImage/Info.plist" ],
+            sources: [ "FLAnimatedImage" ],
             publicHeadersPath: "FLAnimatedImage"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,9 @@ let package = Package(
         .target(
             name: "FLAnimatedImage",
             path: "FLAnimatedImage",
-            exclude: [ "FLAnimatedImage/Info.plist" ],
-            sources: [ "FLAnimatedImage" ],
-            publicHeadersPath: "FLAnimatedImage"
+            exclude: [ "Info.plist" ],
+            sources: [ "./FLAnimatedImage" ],
+            publicHeadersPath: "./FLAnimatedImage"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "FLAnimatedImage",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "FLAnimatedImage",
+            type: .dynamic,
+            targets: ["FLAnimatedImage"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "FLAnimatedImage",
+            path: "FLAnimatedImage",
+            exclude: [ "FLAnimatedImage/Info.plist" ],
+            publicHeadersPath: "FLAnimatedImage"
+        )
+    ]
+)


### PR DESCRIPTION
Due to new Xcode and SPM integration, this PR adds `Package.swift`, which allows Xcode to build and load the package.