### PR TITLE
Updated Swift Package Manager support to fix unknown header issue

### DIFF
--- a/FLAnimatedImage/include/FLAnimatedImage.h
+++ b/FLAnimatedImage/include/FLAnimatedImage.h
@@ -10,8 +10,7 @@
 #import <UIKit/UIKit.h>
 
 // Allow user classes conveniently just importing one header.
-#import <FLAnimatedImage/FLAnimatedImageView.h>
-
+#import "FLAnimatedImageView.h"
 
 #ifndef NS_DESIGNATED_INITIALIZER
     #if __has_attribute(objc_designated_initializer)

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,15 @@ let package = Package(
         .library(name: "FLAnimatedImage", targets: ["FLAnimatedImage"]),
     ],
     targets: [
-        .target(name: "FLAnimatedImage", path: "FLAnimatedImage")
+        .target(
+            name: "FLAnimatedImage",
+            path: "FLAnimatedImage",
+            exclude: [ "Info.plist" ],
+            sources: [ "FLAnimatedImageView.m", "FLAnimatedImage.m" ],
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("include")
+            ]
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ If using [Carthage](https://github.com/Carthage/Carthage), add the following lin
 github "Flipboard/FLAnimatedImage"
 ```
 
+If using [Swift Package Manager](https://github.com/apple/swift-package-manager), add the following to your `Package.swift` or add via XCode:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Flipboard/FLAnimatedImage.git", .upToNextMajor(from: "1.0.16"))
+],
+targets: [
+    .target(name: "TestProject", dependencies: ["FLAnimatedImage""])
+]
+```
+
 In your code, `#import "FLAnimatedImage.h"`, create an image from an animated GIF, and setup the image view to display it:
 
 ```objective-c


### PR DESCRIPTION
Fixes the `'FLAnimatedImage/FLAnimatedImageView.h' file not found` issue.

Relates to:
https://github.com/Flipboard/FLAnimatedImage/issues/247
https://github.com/Flipboard/FLAnimatedImage/issues/228