### PR TITLE
When passing in nil to clear the animated image, remove anything sitting in super.image

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -118,6 +118,8 @@
         } else {
             // Stop animating before the animated image gets cleared out.
             [self stopAnimating];
+            // Clear out the image.
+            super.image = nil;
         }
         
         _animatedImage = animatedImage;


### PR DESCRIPTION
We're already covering the case of clearing out super.nil when setAnimatedImage is not nil. This adds a small tweak to handle when you pass in nil.