### PR TITLE
Reconfigure Frame Rate Divisor

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -312,7 +312,7 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
         const NSTimeInterval kStaticDisplayRefreshRate = 60.0;
 
-        if (@available(iOS 10, *)) {
+        if (@available(iOS 10.3, *)) {
             self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) UIScreen.mainScreen.maximumFramesPerSecond, 1); // 60Hz or 120Hz, depending on device capabilities.
         } else {
             self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kStaticDisplayRefreshRate, 1); // Before iOS 10, no iOS devices support greater refresh rates than 60Hz.

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -29,6 +29,7 @@
 @property (nonatomic, assign) NSUInteger loopCountdown;
 @property (nonatomic, assign) NSTimeInterval accumulator;
 @property (nonatomic, strong) CADisplayLink *displayLink;
+@property (nonatomic, strong) UIScreen *screen;
 
 @property (nonatomic, assign) BOOL shouldAnimate; // Before checking this value, call `-updateShouldAnimate` whenever the animated image or visibility (window, superview, hidden, alpha) has changed.
 @property (nonatomic, assign) BOOL needsDisplayWhenImageBecomesAvailable;
@@ -174,6 +175,7 @@
     [super didMoveToWindow];
     
     [self updateShouldAnimate];
+    [self updateScreen];
     if (self.shouldAnimate) {
         [self startAnimating];
     } else {
@@ -311,9 +313,10 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
         // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display.
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
         const NSTimeInterval kStaticDisplayRefreshRate = 60.0;
+        const NSTimeInterval kVariableDisplayRefreshRate = self.screen.maximumFramesPerSecond;
 
         if (@available(iOS 10.3, *)) {
-            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) UIScreen.mainScreen.maximumFramesPerSecond, 1); // 60Hz or 120Hz, depending on device capabilities.
+            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) kVariableDisplayRefreshRate, 1); // 60Hz or 120Hz, depending on device capabilities.
         } else {
             self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kStaticDisplayRefreshRate, 1); // Before iOS 10, no iOS devices support greater refresh rates than 60Hz.
         }
@@ -376,6 +379,11 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
 {
     BOOL isVisible = self.window && self.superview && ![self isHidden] && self.alpha > 0.0;
     self.shouldAnimate = self.animatedImage && isVisible;
+}
+
+-(void)updateScreen
+{
+    self.screen = self.window.screen;
 }
 
 

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -313,10 +313,9 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
         // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display.
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
         const NSTimeInterval kStaticDisplayRefreshRate = 60.0;
-        const NSTimeInterval kVariableDisplayRefreshRate = self.screen.maximumFramesPerSecond;
 
         if (@available(iOS 10.3, *)) {
-            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) kVariableDisplayRefreshRate, 1); // 60Hz or 120Hz, depending on device capabilities.
+            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) self.screen.maximumFramesPerSecond, 1); // 60Hz or 120Hz, depending on device capabilities.
         } else {
             self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kStaticDisplayRefreshRate, 1); // Before iOS 10, no iOS devices support greater refresh rates than 60Hz.
         }

--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -308,10 +308,15 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
             [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:self.runLoopMode];
         }
 
-        // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display (~60Hz).
+        // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display.
         // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
-        const NSTimeInterval kDisplayRefreshRate = 60.0; // 60Hz
-        self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+        const NSTimeInterval kStaticDisplayRefreshRate = 60.0;
+
+        if (@available(iOS 10, *)) {
+            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * (double) UIScreen.mainScreen.maximumFramesPerSecond, 1); // 60Hz or 120Hz, depending on device capabilities.
+        } else {
+            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kStaticDisplayRefreshRate, 1); // Before iOS 10, no iOS devices support greater refresh rates than 60Hz.
+        }
 
         self.displayLink.paused = NO;
     } else {

--- a/FLAnimatedImageDemo.xcodeproj/project.pbxproj
+++ b/FLAnimatedImageDemo.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				870D79D41936EBFC009D1BCE /* rock.gif */,
 			);
 			name = "test-gifs";
-			path = "FLAnimatedImageDemo/test-gifs";
+			path = "AnimatedImageDemo/animated-gifs";
 			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */

--- a/FLAnimatedImageDemo.xcodeproj/project.pbxproj
+++ b/FLAnimatedImageDemo.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				870D79D41936EBFC009D1BCE /* rock.gif */,
 			);
 			name = "test-gifs";
-			path = "AnimatedImageDemo/animated-gifs";
+			path = "FLAnimatedImageDemo/test-gifs";
 			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Closes #253

## Overview

As discussed in the issue, when using FLAnimatedImage on iPhone 13 Pro devices running iOS 15, GIFs play at ultra speed due to some math assuming that the screen refresh rate will never change.

Unfortunately (or fortunately?) ProMotion is now a thing, so assumptions need to be mitigated.

## Changes

- Made use of `if (@available(iOS 10.3, *)) {` to use the available `UIScreen.mainScreen.maximumFramesPerSecond` value.
- Previous iOS devices can continue using `60Hz`, as devices running <iOS 10.3 do not know about higher refresh rates.

## Considerations

- Explicit cast to `(double)` (NSTimeInterval) for accuracy.