### PR TITLE
Fix playback speed issue on 120Hz displays

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -308,11 +308,14 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
             [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:self.runLoopMode];
         }
 
-        // Note: The display link's `.frameInterval` value of 1 (default) means getting callbacks at the refresh rate of the display (~60Hz).
-        // Setting it to 2 divides the frame rate by 2 and hence calls back at every other display refresh.
-        const NSTimeInterval kDisplayRefreshRate = 60.0; // 60Hz
-        self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
-
+        if (@available(iOS 10, *)) {
+            // Adjusting preferredFramesPerSecond allows us to skip unnecessary calls to displayDidRefresh: when showing GIFs
+            // that don't animate quickly. Use ceil to err on the side of too many FPS so we don't miss a frame transition moment.
+            self.displayLink.preferredFramesPerSecond = ceil(1.0 / [self frameDelayGreatestCommonDivisor]);
+        } else {
+            const NSTimeInterval kDisplayRefreshRate = 60.0; // 60Hz
+            self.displayLink.frameInterval = MAX([self frameDelayGreatestCommonDivisor] * kDisplayRefreshRate, 1);
+        }
         self.displayLink.paused = NO;
     } else {
         [super startAnimating];
@@ -397,7 +400,11 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
                 self.needsDisplayWhenImageBecomesAvailable = NO;
             }
             
-            self.accumulator += displayLink.duration * displayLink.frameInterval;
+            if (@available(iOS 10, *)) {
+                self.accumulator += displayLink.targetTimestamp - CACurrentMediaTime();
+            } else {
+                self.accumulator += displayLink.duration * displayLink.frameInterval;
+            }
             
             // While-loop first inspired by & good Karma to: https://github.com/ondalabs/OLImageView/blob/master/OLImageView.m
             while (self.accumulator >= delayTime) {


### PR DESCRIPTION
Apple devices with 120Hz displays (iPad Pro, iPhone 13 Pro, M1 Pro/Max MacBook Pro) will play back GIFs at a very high speed. This change fixes the issue. The `preferredFramesPerSecond` change isn't _strictly_ necessary, but the `frameInterval` property has been deprecated since iOS 10.

Fixes #253 