### PR TITLE
iPhone 13 Pro will playback at high speed when looping

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -398,7 +398,7 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b)
             }
             
             if (@available(iOS 10, *)) {
-                self.accumulator += displayLink.targetTimestamp - CACurrentMediaTime();
+                self.accumulator += ((NSTimeInterval)1)/((NSTimeInterval)displayLink.preferredFramesPerSecond);
             } else {
                 self.accumulator += displayLink.duration * (NSTimeInterval)displayLink.frameInterval;
             }


### PR DESCRIPTION
Fix an issue that iPhone 13 Pro will playback at high speed when looping.