### PR TITLE
FLAnimatedImage: import using angle-bracketed instead of double-quoted.

### DIFF
--- a/FLAnimatedImage/include/FLAnimatedImage.h
+++ b/FLAnimatedImage/include/FLAnimatedImage.h
@@ -10,7 +10,7 @@
 #import <UIKit/UIKit.h>
 
 // Allow user classes conveniently just importing one header.
-#import "FLAnimatedImageView.h"
+#import <FLAnimatedImage/FLAnimatedImageView.h>
 
 #ifndef NS_DESIGNATED_INITIALIZER
     #if __has_attribute(objc_designated_initializer)


### PR DESCRIPTION
To solve the warning "double-quoted include "FLAnimatedImageView.h" in framework header, expected angle-bracketed instead".